### PR TITLE
Import theme updates from 18F/guides-template

### DIFF
--- a/_go/go.rb
+++ b/_go/go.rb
@@ -1,0 +1,56 @@
+# Author: Mike Bland <michael.bland@gsa.gov>
+
+module GoScript
+  def self.exec_cmd(cmd)
+    exit $?.exitstatus unless system(cmd)
+  end
+
+  # Groups a set of commands by common function.
+  class CommandGroup
+    attr_accessor :description, :commands
+    private_class_method :new
+    @@groups = Array.new
+
+    # @param description [String] short description of the group
+    # @param commands [Hash<Symbol,String>] mapping from command function name
+    #   to a brief description; each key must be the name of a function in this
+    #   script
+    def initialize(description, commands)
+      @description = description
+      @commands = commands
+    end
+
+    def to_s
+      padding = @commands.keys.max_by {|i| i.size}.size + 2
+      ["\n#{@description}"].concat(
+        @commands.map {|name, desc| "  %-#{padding}s#{desc}" % name}).join("\n")
+    end
+
+    def self.add_group(description, commands)
+      @@groups << new(description, commands)
+    end
+
+    def self.groups
+      @@groups
+    end
+
+    def self.check_command_exists(command_symbol)
+      all_commands = @@groups.map {|i| i.commands.keys}.flatten
+      unless all_commands.member? command_symbol
+        puts "Unknown option or command: #{command_symbol}"
+        usage(exitstatus: 1)
+      end
+    end
+
+    def self.usage(exitstatus: 0)
+      puts <<EOF
+Usage: #{$0} [options] [command]
+
+options:
+  -h,--help  Show this help
+EOF
+      GoScript::CommandGroup.groups.each {|s| puts s}
+      exit exitstatus
+    end
+  end
+end

--- a/_go/navigation.rb
+++ b/_go/navigation.rb
@@ -1,0 +1,82 @@
+# Author: Mike Bland <michael.bland@gsa.gov>
+
+require 'safe_yaml'
+
+module GuidesTemplate
+  # Automatically updates the `navigation:` field in _config.yml.
+  #
+  # Does this by parsing the front matter from files in `pages/`. Preserves the
+  # existing order of items in `navigation:`, but new items may need to be
+  # reordered manually.
+  def self.update_navigation_configuration(basedir)
+    config_path = File.join basedir, '_config.yml'
+    config_data = SafeYAML.load_file config_path, safe: true
+    nav_data = config_data['navigation']
+    update_navigation_data nav_data, pages_front_matter_by_title
+    write_navigation_data_to_config_file config_path, nav_data
+  end
+
+  def self.pages_front_matter_by_title
+    Dir[File.join BASEDIR, 'pages', '**', '*.md'].map do |f|
+      front_matter = SafeYAML.load_file f, safe: true
+      [front_matter['title'], front_matter]
+    end.to_h
+  end
+
+  def self.update_navigation_data(nav_data, pages_front_matter_by_title)
+    nav_data_by_title = nav_data.map { |nav| [nav['text'].downcase, nav] }.to_h
+
+    pages_front_matter_by_title.each do |title, front_matter|
+      page_nav = {
+        'text' => title,
+        'url' => "#{front_matter['permalink'].split('/').last}/",
+        'internal' => true,
+      }
+      title = title.downcase
+      parent = (front_matter['parent'] || '').downcase
+
+      if nav_data_by_title.member? title
+        nav_data_by_title[title].merge! page_nav
+
+      elsif parent
+        unless nav_data_by_title.member?(parent)
+          raise StandardError.new("Parent page not present in existing " +
+            "config: #{front_matter['parent']}\n" +
+            "Needed by: #{front_matter['text']}")
+        end
+
+        children = nav_data_by_title[parent]['children']
+        children_by_title = children.map { |i| [i['text'].downcase, i] }.to_h
+
+        if children_by_title.member? title
+          children_by_title[title].merge! page_nav
+        else
+          children << page_nav
+        end
+
+      else
+        nav_data << page_nav
+      end
+    end
+  end
+
+  def self.write_navigation_data_to_config_file(config_path, nav_data)
+    lines = []
+    in_navigation = false
+    open(config_path).each_line do |line|
+      if !in_navigation && line.start_with?('navigation:')
+        lines << line
+        lines << nav_data.to_yaml["---\n".size..-1]
+        in_navigation = true
+      elsif in_navigation
+        if !(line.start_with?(' ') || line.start_with?('-'))
+          in_navigation = false
+          lines << line
+        end
+      else
+        lines << line
+      end
+    end
+    File.write config_path, lines.join
+  end
+end

--- a/_go/repository.rb
+++ b/_go/repository.rb
@@ -1,0 +1,39 @@
+# Author: Mike Bland <michael.bland@gsa.gov>
+
+require_relative 'go'
+require 'fileutils'
+
+module GuidesTemplate
+  TEMPLATE_FILES=%w(
+    pages/child-page.md
+    pages/config.md
+    pages/github.md
+    pages/images.md
+    pages/new-page.md
+    pages/posting.md
+    images/18f-pages.png
+    images/description.png
+    images/gh-add-guide.png
+    images/gh-branches-link.png
+    images/gh-default-branch.png
+    images/gh-settings-button.png
+    images/gh-webhook.png
+    images/images.png
+    )
+
+  def self.remove_template_files(basedir)
+    puts 'Clearing Guides Template files'
+    files = GuidesTemplate::TEMPLATE_FILES.map { |f| File.join basedir, f }
+    File.delete *files
+  end
+
+  def self.create_new_git_repository(basedir)
+    puts 'Removing old git repository'
+    FileUtils.rm_rf File.join(BASEDIR, '.git')
+    puts 'Creating a new git repository'
+    GoScript.exec_cmd "git init '#{BASEDIR}'"
+    puts 'Adding files for initial commit'
+    GoScript.exec_cmd "git add '#{BASEDIR}'"
+    puts "All done! Run \'git commit\' to create your first commit."
+  end
+end

--- a/_go/theme.rb
+++ b/_go/theme.rb
@@ -1,0 +1,39 @@
+# Author: Mike Bland <michael.bland@gsa.gov>
+
+require_relative 'go'
+require 'fileutils'
+require 'tmpdir'
+
+module GuidesTemplate
+  SOURCE_REPO = '18F/guides-template'
+  SOURCE_REPO_ADDRESS = "git@github.com:#{SOURCE_REPO}.git"
+  THEME_COMPONENTS = %w(go _go _includes _layouts assets)
+
+  def self.update_theme_from_guides_template(basedir)
+    puts 'update_theme: Cloning 18F/guides-template into a temporary directory'
+    clone_guides_template_repo do |source_repo|
+      puts 'update_theme: Copying files over from 18F/guides-template'
+      GoScript.exec_cmd('rsync -av --exclude .DS_Store ' +
+        "#{THEME_COMPONENTS.map { |i| File.join source_repo, i }.join(' ')} " +
+        "#{basedir}")
+    end
+
+    puts 'update_theme: Committing updated files'
+    GoScript.exec_cmd "git add '#{basedir}'"
+
+    system "git commit -m 'Import theme updates from #{SOURCE_REPO}'"
+    puts 'update_theme: No updates found' if $?.exitstatus != 0
+    puts 'update_theme: Style update complete'
+  end
+
+  def self.clone_guides_template_repo(&block)
+    begin
+      tmpdir = Dir.mktmpdir
+      repo_dir = File.join tmpdir, 'guides-template'
+      GoScript.exec_cmd "git clone #{SOURCE_REPO_ADDRESS} #{repo_dir}"
+      yield repo_dir
+    ensure
+      FileUtils.rm_rf tmpdir
+    end
+  end
+end

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,9 @@
 <footer role="contentinfo">
   <div class="wrap">
     <p>This project is maintained by <a href="{{ site.author.url }}">{{ site.author.name }}</a>.</p>
-    <p>To share your feedback with us, open an issue or pull request on our <a href="https://github.com/18F/method-cards">GitHub repository.</a></p>
-    <p>Hosted on <a href="https://github.com/18F/pages/">18F Pages</a>.</p>
+
+    <p>Hosted on <a href="https://github.com/18F/pages/">18F Pages</a>.
+    The <a href="https://github.com/18F/guides-template/">18F Guides theme</a> is based on <a href="https://github.com/cfpb/docter/">DOCter</a> from <a href="http://cfpb.github.io/">CFPB</a>.</p>
+    <p><a href="{{ site.repos[0].url }}/edit/18f-pages/{{ page.path }}">Edit this page</a> or <a href="{{ site.repos[0].url }}/issues">file an issue</a> on GitHub.</p>
   </div><!--/.wrap -->
 </footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,6 +3,13 @@
   <meta charset="utf-8">
   <title>{{ page.title }} - {{ site.name }}</title>
   <meta name="viewport" content="width=device-width">
+  <link rel="shortcut icon" type="image/ico" href="{{ site.baseurl }}/images/favicons/favicon.ico" />
+  <link rel="icon" type="image/png" href="{{ site.baseurl }}/images/favicons/favicon.png" />
+  <link rel="apple-touch-icon-precomposed" href="{{ site.baseurl }}/images/favicons/18f-center-57.png">
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ site.baseurl }}/images/favicons/18f-center-72.png">
+  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ site.baseurl }}/images/favicons/18f-center-114.png">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/images/favicons/18f-center-144.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="{{ site.baseurl }}/images/favicons/18f-center-192.png" />
   <link href='//fonts.googleapis.com/css?family=Raleway:400,700%7COpen+Sans:300,600' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/syntax.css">

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,6 @@
 <script src="//code.jquery.com/jquery-1.11.2.min.js"></script>
 <script src="//code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+<script src="{{ site.baseurl }}/assets/js/accordion.js"></script>
 {% if page.title == "Keyboard Access" %}
 <script type="text/javascript">
 	$(document).ready(function(){

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -4,15 +4,26 @@
   <nav class="sidebar-nav" role="navigation">
     <ul>
       {% for link in site.navigation %}
-        {% if link.internal == true %}
-          <li {% if page.title == link.text %}class="sidebar-nav-active"{% endif %}>
-            <a href="{{ site.baseurl }}/{{ link.url }}"  {% if page.title == link.text %}title='Selected'{% endif %}>{{ link.text }}</a>
-          </li>
-        {% else %}
-          <li {% if page.title == link.text %}class="sidebar-nav-active"{% endif %}>
-            <a href="{{ link.url }}" {% if page.title == link.text %}title='Selected'{% endif %}>{{ link.text }}</a>
-          </li>
-        {% endif %}
+        <li class="group {% if page.title == link.text %}sidebar-nav-active{% endif %}">
+          <a href="{% if link.internal == true %}{{ site.baseurl }}/{% endif %}{{ link.url }}"  
+            title="{% if page.title == link.text %}Current Page
+                  {% else %}{{ link.text }}{% endif %}">{{ link.text }}</a>
+          {% if link.children %}
+            <button class="expand-subnav"
+                    aria-expanded="{% if link.text == page.parent or link.text == page.title %}true{% else %}false{% endif %}"
+                    aria-controls="nav-collapsible-{{ forloop.index }}">+</button>
+            <ul class="nav-children" id="nav-collapsible-{{ forloop.index }}" 
+                aria-hidden="{% if link.text == page.parent or link.text == page.title %}false{% else %}true{% endif %}">
+              {% for child in link.children %}
+                <li class="{% if page.title == child.text %}sidebar-nav-active{% endif %}">
+                  <a href="{% if link.internal == true %}{{ site.baseurl }}/{{ link.url }}{% endif %}{{ child.url }}"  
+                    title="{% if page.title == child.text %}Current Page
+                          {% else %}{{ child.text }}{% endif %}">{{ child.text }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </li>
       {% endfor %}
     </ul>
   </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,23 +22,14 @@
 
         {% include sidebar.html %}
 
-        <section id="main" class="main-content method
-          {% if page.category != page.title %}
-             {{ page.category | prepend:'category' }}
-          {% elsif page.title == page.category %}
-             parent parent{{page.category}}
-           {% endif %}" role="main">
-          <header>
-            <h1>{{ page.title }}</h1>
-            {% if page.category != page.title %}<h2><a href="{{ site.baseurl }}/{{ page.category | downcase }}">{{ page.category }}</a></h2>{% endif %}
-          <div style="clear:both"></div>
-          </header>
+        <section id="main" class="main-content" role="main">
+          <h1>{{ page.title }}</h1>
           {{ content }}
         </section>
 
       </div><!-- /.wrap content -->
 
-      {% include footer.html %}
+      {% include footer.html%}
 
     </div> <!-- /.container -->
 

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -40,34 +40,3 @@ li.active > a{
 	background-color: #317ab9;
 }
 
-H1 { font-size: 2em }
-
-.categoryDiscover header h2,     .parentDiscover header h1     { border: 2px solid #4980BE }
-.categoryDecide header h2,       .parentDecide header h1       { border: 2px solid #51AC4F }
-.categoryMake header h2,         .parentMake header h1         { border: 2px solid #EDA734 }
-.categoryValidate header h2,     .parentValidate header h1     { border: 2px solid #CE5D30 }
-.categoryFundamentals header h2, .parentFundamentals header h1 { border: 2px solid #123B5B }
-
-
-.method header h1 {
-	margin: 0;
-	float: left;
-}
-.method header h2 {
-	position: absolute;
-	right: 1em;
-	margin: 0;
-/*	float:right;*/
-	font-weight: normal;
-	font-size: 1.2em;
-	padding: 0.5em;
-}
-
-.parent header h1 {
-	padding-bottom: 0.46em;
-	margin-bottom: 0.9em;
-	float: none;
-	border-top: none;
-	border-left: none;
-	border-right: none;
-}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -39,6 +39,7 @@ body {
     font-weight: 400;
     font-style: normal;
     line-height: 1.466666667;
+    margin: 0;
 }
 
 h1,
@@ -173,36 +174,123 @@ Navigation
   padding: 10px;
   -webkit-transition: .4s;
   transition: .4s;
+  width: 80%;
+  float: left;
 }
+
 .sidebar-nav a,
 .sidebar-nav a:link,
 .sidebar-nav a:visited {
   border-bottom: none;
   color: #74767B;
 }
-.sidebar-nav li:hover,
+
+.sidebar-nav a:hover,
 .sidebar-nav a:focus,
-.sidebar-nav li:active,
-.sidebar-nav .sidebar-nav-active {
+.sidebar-nav a:active,
+.sidebar-nav .sidebar-nav-active > a {
   color: #74767B;
   border-left: 4px solid {{ site.brand_color }};
   background-color: transparent;
-  padding-left: 0;
 }
+
 .sidebar-nav ul {
   margin: 0;
   padding: 0;
 }
+
 .sidebar-nav li {
   list-style: none;
   border-bottom: 1px solid #babbbd;
   font-size: 1.125em;
   padding-left: 4px;
+  overflow: hidden;
 }
+
 .sidebar-nav li:last-child {
   border-bottom: none;
 }
 
+.nav-children {
+    clear: both;
+    display: block;
+    font-size: 14px;
+    max-height: 0;
+    opacity: 0;
+    overflow: hidden;
+    position: relative;
+    -webkit-transition: max-height .2s, opacity .2s;
+    -moz-transition: max-height .2s, opacity .2s;
+    -o-transition: max-height .2s, opacity .2s;
+    transition: max-height .2s, opacity .2s;
+}
+
+.nav-children li {
+    border-bottom: none;
+    padding-left: 0;
+}
+
+.nav-children a {
+    padding: 5px 5px 5px 20px;
+}
+
+.nav-children li:last-child a {
+    padding-bottom: 10px;
+}
+
+.expand-subnav {
+    background: none;
+    border: none;
+    border-radius: 30px;
+    color: #0072ce;
+    cursor: pointer;
+    display: block;
+    float: right;
+    font-size: 20px;
+    height: 30px;
+    line-height: 1;
+    margin: 8px;
+    padding-bottom: 5px;
+    position: relative;
+    width: 30px;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -o-appearance: none;
+    appearance: none;    
+    -webkit-transition: -webkit-transform .2s;
+    -moz-transition: -moz-transform .2s;
+    -o-transition: -o-transform .2s;
+    transition: transform .2s;
+}
+
+.expand-subnav:hover,
+.expand-subnav:focus {
+    background-color: #0072ce;
+    color: #fff;
+    outline: none;
+}
+
+.expand-subnav[aria-expanded=true] {
+    -webkit-transform: rotate(45deg);
+    -moz-transform: rotate(45deg);
+    -o-transform: rotate(45deg);
+    transform: rotate(45deg);
+}
+
+
+.nav-children[aria-hidden=true] {
+    max-height: 0;
+}
+
+.nav-children {
+    display: block;
+    max-height: 400px;
+    opacity: 1;
+    -webkit-transition: max-height .2s, opacity .2s;
+    -moz-transition: max-height .2s, opacity .2s;
+    -o-transition: max-height .2s, opacity .2s;    
+    transition: max-height .2s, opacity .2s;
+}
 
 /*
 Layout
@@ -233,7 +321,7 @@ section:before {
     padding-right: 20px;
 }
 
-.container > header {
+header {
     width: 100%;
     border-bottom: 4px solid {{ site.brand_color }};
     background-color: #fff;
@@ -433,6 +521,10 @@ Desktop Styles
         width: 67%;
         float: right;
         margin-bottom: 120px;
+    }
+
+    .main-content img {
+        max-width: 100%;
     }
 
     /*

--- a/assets/js/accordion.js
+++ b/assets/js/accordion.js
@@ -1,0 +1,53 @@
+/*  Originally from the Government Wide Pattern Library.
+    Modified to check for items expanded on page load and
+    to allow you to close an accordion without opening another
+*/
+
+function Accordion($el) {
+  var self = this;
+  this.$root = $el;
+  this.$root.on('click', 'button', function(ev) {
+    ev.preventDefault();
+    if ( $(this).attr('aria-expanded') === 'true' ) {
+      self.hide($(this));
+    } else {
+      self.show($(this));
+    }
+  });
+
+}
+
+Accordion.prototype.$ = function(selector) {
+  return this.$root.find(selector);
+}
+
+Accordion.prototype.hide = function($button) {
+  var selector = $button.attr('aria-controls'),
+      $content = this.$('#' + selector);
+  $button.attr('aria-expanded', false);
+  $content.attr('aria-hidden', true);
+};
+
+Accordion.prototype.show = function($button) {
+  var selector = $button.attr('aria-controls'),
+      $content = this.$('#' + selector);
+  $button.attr('aria-expanded', true);
+  $content.attr('aria-hidden', false);
+};
+
+Accordion.prototype.hideAll = function() {
+  var self = this;
+  this.$('button').each(function() {
+    self.hide($(this));
+  });
+};
+
+function accordion($el) {
+  return new Accordion($el);
+}
+
+$(function() {
+  $('.sidebar-nav').each(function() {
+    accordion($(this));
+  });
+});


### PR DESCRIPTION
This includes the [child page feature](https://pages.18f.gov/guides-template/adding-a-new-page/making-a-child-page/) that @vz3 expressed an interest in.

Also note that now you can run `./go update_nav` to automatically update the nav structure of `_config.yml`, so you don't have to do it all by hand, should you choose to split these pages into child pages.

If some of the changes are destructive to work you've already done, I'm happy to tweak as needed, or you're welcome to pull the branch and push updates/reversions yourself.