### PR TITLE
Enabling Travis CI, CloundFoundry on production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: true
+language: ruby
+rvm:
+- 2.1
+script: jekyll build --config _config.yml,_config-production.yml ./_site
+deploy:
+  provider: cloudfoundry
+  edge: true
+  api: https://api.18f.gov
+  organization: 18f
+  space: methods
+  username: deploy-18f
+  password:
+    secure: a/rj9TMgm8W+ez6SSb9wv+EVvtILI5tGRzjcY/Ntk1Ty9JchHZU95OfM9i1K0EbSHdGWRWj0wVx5/O8g2Rpaiebn5HHLnP8jwVMS27ZNq5KGXeku/ewp$
+  on:
+    repo: 18F/methods
+    branch: 18f-pages
+branches:
+  only:
+    - 18f-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ deploy:
     branch: 18f-pages
 branches:
   only:
-    - production
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ deploy:
     branch: 18f-pages
 branches:
   only:
-    - 18f-pages
+    - production

--- a/Staticfile
+++ b/Staticfile
@@ -1,0 +1,1 @@
+root: _site

--- a/_config-production.yml
+++ b/_config-production.yml
@@ -1,0 +1,1 @@
+baseurl:

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,6 @@
+---
+applications:
+- name: notalone
+buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git 
+memory: 64M
+instances: 1

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: notalone
+- name: methods
 buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git 
 memory: 64M
 instances: 1


### PR DESCRIPTION
When pushed to the "18f-pages" branch, these files should:
1. Build the Jekyll site (using both _config.yml and _config-production.yml, so the built version has the right base URL for deployment to methods.18f.gov). 
2. Push the built version to the "methods" CloudFoundry space, which is viewable at methods.18f.gov

I am a bit outside my comfort zone here, so I'd really appreciate your review, @vz3 and @ozzyjohnson. Thanks so much for all your help!