### PR TITLE
Enabling Travis CI and Cloud Foundry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: true
 language: ruby
 rvm:
 - 2.1
-script: jekyll build --config _config.yml,_config-production.yml ./_site
+script: bundle exec jekyll --config _config.yml,_config-production.yml ./_site
 deploy:
   provider: cloudfoundry
   edge: true

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer role="contentinfo">
   <div class="wrap">
     <p>This project is maintained by <a href="{{ site.author.url }}">{{ site.author.name }}</a>.</p>
-    <p>To share your feedback with us, open an issue or pull request on our <a href="https://github.com/18F/method-cards">GitHub repository.</a></p>
+    <p>To share your feedback with us, open an issue or pull request on our <a href="https://github.com/18F/methods">GitHub repository.</a></p>
     <p>Hosted on <a href="https://github.com/18F/pages/">18F Pages</a>.</p>
   </div><!--/.wrap -->
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,6 +2,6 @@
   <div class="wrap">
     <p>This project is maintained by <a href="{{ site.author.url }}">{{ site.author.name }}</a>.</p>
     <p>To share your feedback with us, open an issue or pull request on our <a href="https://github.com/18F/methods">GitHub repository.</a></p>
-    <p>Hosted on <a href="https://github.com/18F/pages/">18F Pages</a>.</p>
+    <p>Hosted on <a href="{{ site.repos.url }}">18F Pages</a>.</p>
   </div><!--/.wrap -->
 </footer>


### PR DESCRIPTION
When pushed to the "master" branch, these files should:
1. Build the Jekyll site (using both _config.yml and _config-production.yml, so the built version has the right base URL for deployment to methods.18f.gov). 
2. Push the built version to the "methods" CloudFoundry space, which is viewable at methods.18f.gov
