### PR TITLE
Cognitive walkthrough update

### DIFF
--- a/pages/card-sorting.md
+++ b/pages/card-sorting.md
@@ -35,7 +35,7 @@ There are two types of card sorting: open and closed. Most card sorts are perfor
 
 1. Give users a collection of content represented on cards.
 
-2. Ask the user to parse it into a list of categories you have predefined.
+2. Ask users to parse the content into a list of categories you have predefined.
 
 3. Ask users to tell you why they assigned cards to the categories they did.
 

--- a/pages/cognitive-walkthrough.md
+++ b/pages/cognitive-walkthrough.md
@@ -19,17 +19,17 @@ To understand whether a design solution is easy for a new or infrequent user to 
 
 ## How to do it
 
-1. Determine the representative users that would be new users or infrequent users of a design solution.
+1. Identify specific traits for new or infrequent users of a design solution.
 
-2. Develop representative tasks a user would attempt that emphasis new use or infrequent use.
+2. Develop a set of representative tasks that emphasis new use or infrequent use.
 
-3. Recruit 3–5 users per user group that makes up the user population that are willing to participant in a moderated usability testing session.
+3. Recruit three to five users for each of the traits you’ve identified to participant in a moderated usability testing session. (The traits can overlap.)
 
-4. Facilitate a walkthrough a solution where probing questions focus on what people would initially attempt to do, or how they would learn how to navigate the solution to accomplish the tasks.  
- - Encourage the user the stay on task without leading them.
+4. Ask the user to accomplish their goal using a printed or interactive design. As they go, ask what they would attempt to do next or how they would learn.
+ - Don't lead the user through the task, but encourage them to stay focused on what they’re trying to accomplish.
  - Pay attention to expected outcomes and how quickly/easily participants are able to pick up a task.
 
-5. Present the analysis of the cognitive walkthrough that highlights the finding for how learnable the solution is and where areas of improvement can be made.
+5. Analyze the walkthrough results to highlight what users learned easily and what needs improvement.
 
 ## Applied in government research
 

--- a/pages/cognitive-walkthrough.md
+++ b/pages/cognitive-walkthrough.md
@@ -21,7 +21,7 @@ To understand whether a design solution is easy for a new or infrequent user to 
 
 1. Identify specific traits for new or infrequent users of a design solution.
 
-2. Develop a set of representative tasks that emphasis new use or infrequent use.
+2. Develop a set of representative tasks that emphasize new use or infrequent use.
 
 3. Recruit three to five users for each of the traits you’ve identified to participant in a moderated usability testing session. (The traits can overlap.)
 

--- a/pages/cognitive-walkthrough.md
+++ b/pages/cognitive-walkthrough.md
@@ -23,7 +23,7 @@ To understand whether a design solution is easy for a new or infrequent user to 
 
 2. Develop a set of representative tasks that emphasize new use or infrequent use.
 
-3. Recruit three to five users for each of the traits you’ve identified to participant in a moderated usability testing session. (The traits can overlap.)
+3. Recruit three to five users for each of the traits you’ve identified to participate in a moderated usability testing session. (The traits can overlap.)
 
 4. Ask the user to accomplish their goal using a printed or interactive design. As they go, ask what they would attempt to do next or how they would learn.
  - Don't lead the user through the task, but encourage them to stay focused on what they’re trying to accomplish.

--- a/pages/decide.md
+++ b/pages/decide.md
@@ -12,9 +12,9 @@ Use what you’ve learned to start focusing your research on specific areas and 
 - [Comparative analysis](../comparative-analysis/)
 - [Content audit](../content-audit/)
 - [Design principles](../design-principles/)
+- [Site mapping](../site-mapping/)
 - [Task flow analysis](../task-flow-analysis/)
 - [User scenarios](../user-scenarios/)
-- [Site mapping](../site-mapping/)
 
 ### Models
 

--- a/pages/mental-modeling.md
+++ b/pages/mental-modeling.md
@@ -21,7 +21,7 @@ To help designers anticipate how design decisions might facilitate future behavi
 
 1. Create one three-columned table per persona. Label the columns “Past,” “Present Behavior,”  and “Future.”
 
-2. In the middle column (“Present Behavior”), list current user current behaviors and pain points broadly related to the project, one per row.
+2. In the middle column (“Present Behavior”), list current user behaviors and pain points broadly related to the project, one per row.
 
 3. In the left-hand column (“Past”), list the products, services, features, and/or interfaces that the user encounters as they go about what’s listed in the present behaviors column.
 


### PR DESCRIPTION
## Changes
Updated the congitive walkthrough method. The substance of it was fine, but the language needed editing to bring it in line with where the other methods are.

Additional small things:
* Fixed an alphabetical ordering issue on Decide.
* Made two small edits to other cards, one for number and one to remove an extra word.

## Notes
* I re-checked all the methods after making the cognitive walkthrough update, so we shouldn’t need anything this significant again soon. The other methods all reflected edits we’d made offline. I think I just overlooked just the how-to section of that card.
* This PR addresses #27.