### PR TITLE
Fix broken link in Protosketching

### DIFF
--- a/pages/protosketching.md
+++ b/pages/protosketching.md
@@ -35,4 +35,4 @@ No PRA implications. The PRA explicitly exempts direct observation and non-stand
 
 ## Additional resources
 
-[`https://18f.gsa.gov/2015/01/06/protosketch/`]([https://18f.gsa.gov/2015/01/06/protosketch/])
+[`https://18f.gsa.gov/2015/01/06/protosketch/`](https://18f.gsa.gov/2015/01/06/protosketch/)


### PR DESCRIPTION
Currently the online version links to: "https://methods.18f.gov/protosketching/%5Bhttps://18f.gsa.gov/2015/01/06/protosketch/%5D"

Broken link on this page: https://methods.18f.gov/protosketching/
