### PR TITLE
Fixing consent form links

### DIFF
--- a/pages/informed-consent.md
+++ b/pages/informed-consent.md
@@ -31,4 +31,4 @@ Informed consent is the cornerstone of ethical research practice. Always. If you
 No PRA implications. The PRA specifically exempts consents, 5 CFR 1320.3(h)1.
 
 ## Additional resources
-* [18F's participant consent form](./assets/downloads/18FResearchParticipantConsentForm.docx)
+* [18F's participant consent form](../assets/downloads/18FResearchParticipantConsentForm.docx)

--- a/pages/recruiting.md
+++ b/pages/recruiting.md
@@ -42,4 +42,4 @@ If you recruit users who participate for free and aren’t government employees,
 If you do not ask potential participants to respond to a “screener survey,” the PRA does not apply to your recruiting efforts.
 
 ## Additional resources
-* [18F's participant consent form](./assets/downloads/18FResearchParticipantConsentForm.docx), which offers Anti-Deficiency Act-compliant language
+* [18F's participant consent form](../assets/downloads/18FResearchParticipantConsentForm.docx), which offers Anti-Deficiency Act-compliant language


### PR DESCRIPTION
Fixing broken consent form links on both the "recruiting" and "informed consent" card.