### PR TITLE
Fixing local instance URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ ./go serve
 This will check that your Ruby version is supported, install the [Bundler
 gem](http://bundler.io/) if it is not yet installed, install all the gems
 needed by the template, and launch a running instance on
-`http://localhost:4000/methods/`. (Make sure to include the trailing slash! The built-in
+`http://localhost:4000/`. (Make sure to include the trailing slash! The built-in
 Jekyll webserver doesn’t redirect to it.) You can see how your local copy of Methods renders
 at any time by going to that URL. To stop serving locally, simply type `Ctrl+C`
 into the terminal again.


### PR DESCRIPTION
## Changes
Not sure why /methods/ worked for me before, but I just tested it and it doesn’t anymore. Ending on the port number does, though.

## Review
@colinpmacarthur 
@jenniferthibault 

(Just because you two were active  on this project earlier; it’s really anyone who has 30 seconds to serve the site locally and see how it works.)