### PR TITLE
Add _config_18f_pages.yml to set asset_root

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     go_script (0.1.4)
       bundler (~> 1.10)
       safe_yaml (~> 1.0)
-    guides_style_18f (0.1.1)
+    guides_style_18f (0.1.4)
       jekyll (~> 2.5)
       rouge (~> 1.9)
       sass (~> 3.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     go_script (0.1.4)
       bundler (~> 1.10)
       safe_yaml (~> 1.0)
-    guides_style_18f (0.1.4)
+    guides_style_18f (0.1.5)
       jekyll (~> 2.5)
       rouge (~> 1.9)
       sass (~> 3.4)

--- a/_config_18f_pages.yml
+++ b/_config_18f_pages.yml
@@ -1,0 +1,2 @@
+baseurl: /methods
+asset_root: /methods

--- a/go
+++ b/go
@@ -36,19 +36,19 @@ def_command :update_nav, 'Update the \'navigation:\' data in _config.yml' do
 end
 
 def_command :update_theme, 'Update the guides_style_18f gem' do
-  exec({ 'RUBYOPT' => nil }, 'bundle', *%w(update --source guides_style_18f))
+  GuidesStyle18F.update_theme
 end
 
 def_command :update_gems, 'Update Ruby gems' do |gems|
   update_gems gems
 end
 
-def_command :serve, 'Serve the site at localhost:4000' do
-  serve_jekyll
+def_command :serve, 'Serve the site at localhost:4000' do |args|
+  serve_jekyll args
 end
 
-def_command :build, 'Build the site' do
-  build_jekyll
+def_command :build, 'Build the site' do |args|
+  build_jekyll args
 end
 
 execute_command ARGV


### PR DESCRIPTION
Necessary since this repo contains many of its own style settings. Closes #54.

To try this out locally, run `./go serve --config _config.yml,_config_18f_pages.yml`.

Also updates the `./go` script so you can pass arguments to `./go build` and `./go serve`, and bumps the `guides_style_18f` theme to the latest, v0.1.4.

cc: @jenniferthibault @vz3 @jameshupp 