### PR TITLE
Formatting hyperlinks in "Additional resources" section

### DIFF
--- a/pages/affinity-diagramming.md
+++ b/pages/affinity-diagramming.md
@@ -30,5 +30,5 @@ No PRA implications. This method may use data gathered from members of the publi
 
 ## Additional resources
 
-- [`http://www.usabilitybok.org/affinity-diagram`](http://www.usabilitybok.org/affinity-diagram)
-- [`http://infodesign.com.au/usabilityresources/affinitydiagramming/`](http://infodesign.com.au/usabilityresources/affinitydiagramming/)
+- [An explanation of what affinity diagramming is and how to do it.](http://www.usabilitybok.org/affinity-diagram). The Usability Body of Knowledge, a product of the User Experience Professionals’ Association.
+- [An explanation of affinity diagramming.](http://infodesign.com.au/usabilityresources/affinitydiagramming/). Information and Design.

--- a/pages/bodystorming.md
+++ b/pages/bodystorming.md
@@ -35,4 +35,4 @@ To remind participants that interactions are human and physical, to teach stakeh
 
 ## Additional resources
 
-- [`https://www.wickedproblems.com/6_bodystorming.php`](https://www.wickedproblems.com/6_bodystorming.php)
+- [An explanation of bodystorming on Wicked Problems Worth Solving.](https://www.wickedproblems.com/6_bodystorming.php) Austin Center for Design.

--- a/pages/cognitive-walkthrough.md
+++ b/pages/cognitive-walkthrough.md
@@ -36,5 +36,4 @@ To understand whether a design solution is easy for a new or infrequent user to 
 -  If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.
 
 ## Additional resources
-- [`http://www.usabilitybok.org/cognitive-walkthrough`](http://www.usabilitybok.org/cognitive-walkthrough)
-- [`http://www.usabilityfirst.com/usability-methods/cognitive-walkthroughs/`](http://www.usabilitybok.org/cognitive-walkthrough)
+- [An explanation of cognitive walkthroughs and how to conduct one.](http://www.usabilitybok.org/cognitive-walkthrough) The Usability Body of Knowledge, a product of the User Experience Professionals’ Association.

--- a/pages/content-audit.md
+++ b/pages/content-audit.md
@@ -40,5 +40,5 @@ To identify content that needs to be revised in new versions of a website. Conte
 No PRA implications. No information is collected from members of the public.
 
 ## Additional resources
-- [`http://uxmastery.com/how-to-conduct-a-content-audit/`](http://uxmastery.com/how-to-conduct-a-content-audit/)
-- [`http://blog.braintraffic.com/2012/04/auditing-big-sites-doesn%E2%80%99t-have-to-be-taxing/`](http://blog.braintraffic.com/2012/04/auditing-big-sites-doesn%E2%80%99t-have-to-be-taxing/)
+- [“How to Conduct a Content Audit.”](http://uxmastery.com/how-to-conduct-a-content-audit/). UX Mastery.
+- [“Auditing Big Sites Doesn’t Have to Be Taxing.”](http://blog.braintraffic.com/2012/04/auditing-big-sites-doesn%E2%80%99t-have-to-be-taxing/). Christine Anameier.

--- a/pages/design-pattern-library.md
+++ b/pages/design-pattern-library.md
@@ -34,6 +34,6 @@ No PRA implications. No information is collected from members of the public.
 
 ## Additional resources
 
--  [`https://boagworld.com/design/pattern-library/`](https://boagworld.com/design/pattern-library/)
--  [`http://alistapart.com/blog/post/getting-started-with-pattern-libraries`](http://alistapart.com/blog/post/getting-started-with-pattern-libraries)
--  [`http://www.slideshare.net/WolfBruening/how-to-build-the-perfect-pattern-libraryy`](http://www.slideshare.net/WolfBruening/how-to-build-the-perfect-pattern-libraryy)
+-  [“How and Why to Create a Pattern Library.”](https://boagworld.com/design/pattern-library/) Paul Boag.
+- [“Getting Started With Pattern Libraries.”](http://alistapart.com/blog/post/getting-started-with-pattern-libraries) Anna Debenham. 
+- [“How to Build the Perfect Pattern Library.”](http://www.slideshare.net/WolfBruening/how-to-build-the-perfect-pattern-libraryy) Wolf Brün. 

--- a/pages/design-principles.md
+++ b/pages/design-principles.md
@@ -36,4 +36,4 @@ No PRA implications. Generally, no information is collected from members of the 
 
 ## Additional resources
 
-[`http://www.smashingmagazine.com/2015/02/27/design-principles-dominance-focal-points-hierarchy/`](http://www.smashingmagazine.com/2015/02/27/design-principles-dominance-focal-points-hierarchy/)
+- [“Design Principles: Dominance, Focal Points And Hierarchy.”](http://www.smashingmagazine.com/2015/02/27/design-principles-dominance-focal-points-hierarchy/) Steven Bradley. 

--- a/pages/design-studio.md
+++ b/pages/design-studio.md
@@ -38,4 +38,5 @@ No PRA implications. If conducted with nine or fewer members of the public, the 
 
 ## Additional resources
 
-[`https://vimeo.com/37861987/`](https://vimeo.com/37861987/)
+- A [presentation by Todd Zaki Warfel.](https://vimeo.com/37861987/)
+ explaining what Design Studio is. Todd Zaki Warfel.

--- a/pages/feature-dot-voting.md
+++ b/pages/feature-dot-voting.md
@@ -36,6 +36,3 @@ To build group consensus quickly from the priorities of individual in the group.
 
 No PRA implications: feature dot voting falls under "direct observation", which is explicitly exempt from the PRA, 5 CFR 1320(h)3. See the methods for [Recruiting](../recruiting/) and [Privacy](../privacy/) for more tips on taking input from the public.
 
-## Additional resources
-
-[`http://www.nadeemullakhan.com/prioritize-using-dot-voting-agile-innovation-game/`](http://www.nadeemullakhan.com/prioritize-using-dot-voting-agile-innovation-game/)

--- a/pages/heuristic-analysis.md
+++ b/pages/heuristic-analysis.md
@@ -33,5 +33,5 @@ No PRA Implications, as heuristic evaluations usually include a small number of 
 
 ## Additional resources
 
-- [`http://www.nngroup.com/articles/ten-usability-heuristics/`](http://www.nngroup.com/articles/ten-usability-heuristics/)
-- [`http://www.nngroup.com/articles/how-to-conduct-a-heuristic-evaluation/`](http://www.nngroup.com/articles/how-to-conduct-a-heuristic-evaluation/)
+- [“10 Usability Heuristics for User Interface Design.”](http://www.nngroup.com/articles/ten-usability-heuristics/) Jakob Nielsen.
+- [“How to Conduct a Heuristic Evaluation.”](http://www.nngroup.com/articles/how-to-conduct-a-heuristic-evaluation/) Jakob Nielsen.

--- a/pages/informed-consent.md
+++ b/pages/informed-consent.md
@@ -30,4 +30,5 @@ Informed consent is the cornerstone of ethical research practice. Always. If you
 No PRA implications. The PRA specifically exempts consents, 5 CFR 1320.3(h)1.
 
 ## Additional resources
-* [18F's participant consent form](../assets/downloads/18FResearchParticipantConsentForm.docx)
+
+- [18F's participant consent form](../assets/downloads/18FResearchParticipantConsentForm.docx)

--- a/pages/journey-mapping.md
+++ b/pages/journey-mapping.md
@@ -37,6 +37,6 @@ No PRA implications. The PRA explicitly exempts direct observation and non-stand
 
 ## Additional resources
 
-- [`http://adaptivepath.s3.amazonaws.com/apguide/download/Adaptive_Paths_Guide_to_Experience_Mapping.pdf`](http://adaptivepath.s3.amazonaws.com/apguide/download/Adaptive_Paths_Guide_to_Experience_Mapping.pdf)
-- [`https://www.wickedproblems.com/6_journey_maps.php`](https://www.wickedproblems.com/6_journey_maps.php)
-- [`http://www.uxbooth.com/articles/designing-digital-strategies-part-1-cartography/`](http://www.uxbooth.com/articles/designing-digital-strategies-part-1-cartography/)
+- [Adaptive Path’s Guide to Experience Mapping](http://adaptivepath.s3.amazonaws.com/apguide/download/Adaptive_Paths_Guide_to_Experience_Mapping.pdf) Adaptive Path (PDF).
+- [An explanation of journey mapping on Wicked Problems Worth Solving.](https://www.wickedproblems.com/6_journey_maps.php) Austin Center for Design. 
+- [“Designing Digital Strategies, Part 1: Cartography.”](http://www.uxbooth.com/articles/designing-digital-strategies-part-1-cartography/) UX Booth. 

--- a/pages/kj-method.md
+++ b/pages/kj-method.md
@@ -40,7 +40,7 @@ Likely no PRA implications: generally any given session is likely to have nine o
 
 ## Additional resources
 
-[`http://www.uie.com/articles/kj_technique/`](http://www.uie.com/articles/kj_technique/)
+- [“The KJ-Technique: A Group Process for Establishing Priorities.”](http://www.uie.com/articles/kj_technique/) Jared M. Spool. 
 
 ## Example from 18F
 

--- a/pages/mental-modeling.md
+++ b/pages/mental-modeling.md
@@ -32,5 +32,5 @@ No PRA implications. No information is collected from members of the public.
 
 ## Additional resources
 
-- [`http://rosenfeldmedia.com/books/mental-models/`](http://rosenfeldmedia.com/books/mental-models/)
-- [`http://uxmag.com/articles/the-secret-to-designing-an-intuitive-user-experience`](http://uxmag.com/articles/the-secret-to-designing-an-intuitive-user-experience)
+- [*Mental Models: Aligning Design Strategy with Human Behavior.*](http://rosenfeldmedia.com/books/mental-models/) Indi Young. 
+- [“The Secret to Designing an Intuitive UX : Match the Mental Model to the Conceptual Model.”](http://uxmag.com/articles/the-secret-to-designing-an-intuitive-user-experience) Susan Weinschenk, UX Magazine. 

--- a/pages/metrics-definition.md
+++ b/pages/metrics-definition.md
@@ -34,8 +34,8 @@ No PRA implications. No information is collected from members of the public.
 
 ## Additional resources
 
-- [`http://www.uxmatters.com/mt/archives/2009/12/needs-resources-location-schedule-budget-scope.php`](http://www.uxmatters.com/mt/archives/2009/12/needs-resources-location-schedule-budget-scope.php)
-- [`http://alistapart.com/article/no-one-nos-learning-to-say-no-to-bad-ideas`](http://alistapart.com/article/no-one-nos-learning-to-say-no-to-bad-ideas)
-- [`https://www.youtube.com/watch?v=oAU0c7ocZKs`](https://www.youtube.com/watch?v=oAU0c7ocZKs)
-- [`https://civicquarterly.com/article/two-way-streets/`](https://civicquarterly.com/article/two-way-streets/)
-- [`http://articles.latimes.com/2013/apr/07/opinion/la-oe-0407-silk-ring-theory-20130407`](http://articles.latimes.com/2013/apr/07/opinion/la-oe-0407-silk-ring-theory-20130407)
+- [“Needs + Resources + Location + Schedule + Budget = Scope.”](http://www.uxmatters.com/mt/archives/2009/12/needs-resources-location-schedule-budget-scope.php). Whitney Hess.
+- [“No One Nos: Learning to Say No to Bad Ideas.”](http://alistapart.com/article/no-one-nos-learning-to-say-no-to-bad-ideas). Whitney Hess.
+- Video: [Understanding Impact: The mySociety agenda.](https://www.youtube.com/watch?v=oAU0c7ocZKs). Dr. Rebecca Rumbul.
+- [“How not to say the wrong thing”](http://articles.latimes.com/2013/apr/07/opinion/la-oe-0407-silk-ring-theory-20130407). Susan Silk and Barry Goldman.
+

--- a/pages/multivariate-testing.md
+++ b/pages/multivariate-testing.md
@@ -34,5 +34,6 @@ No PRA implications. No one asks the users questions, so the PRA does not apply.
 
 ## Additional resources
 
-- [`http://www.smashingmagazine.com/2010/11/24/multivariate-testing-in-action-five-simple-steps-to-increase-conversion-rates/`](http://www.smashingmagazine.com/2010/11/24/multivariate-testing-in-action-five-simple-steps-to-increase-conversion-rates/)
-- [`http://www.smashingmagazine.com/2011/04/04/multivariate-testing-101-a-scientific-method-of-optimizing-design/`](http://www.smashingmagazine.com/2011/04/04/multivariate-testing-101-a-scientific-method-of-optimizing-design/)
+- [Multivariate Testing in Action: Five Simple Steps to Increase Conversion Rates.](http://www.smashingmagazine.com/2010/11/multivariate-testing-in-action-five-simple-steps-to-increase-conversion-rates/) Paras Chopra. 
+- [Multivariate Testing 101: A Scientific Method of Optimizing Design.](http://www.smashingmagazine.com/2011/04/multivariate-testing-101-a-scientific-method-of-optimizing-design/) Paras Chopra. 
+

--- a/pages/personas.md
+++ b/pages/personas.md
@@ -34,8 +34,7 @@ No PRA implications. No information is collected from members of the public.
 
 ## Additional resources
 
-- [`http://www.uie.com/articles/perfecting_personas/`](http://www.uie.com/articles/perfecting_personas/)
-- [`http://www.amazon.com/Designing-Digital-Age-Human-Centered-Products/dp/0470229101`](http://www.amazon.com/Designing-Digital-Age-Human-Centered-Products/dp/0470229101)
-- [`http://www.cooper.com/journal/2014/04/inside-goal-directed-design-a-two-part-conversation-with-alan-cooper`](http://www.cooper.com/journal/2014/04/inside-goal-directed-design-a-two-part-conversation-with-alan-cooper)
-- [`http://www.amazon.com/The-Design-Everyday-Things-Expanded/dp/0465050654/`](http://www.amazon.com/The-Design-Everyday-Things-Expanded/dp/0465050654/)
-- [`http://www.uxbooth.com/articles/focusing-interaction-design-with-design-strategy/`](http://www.uxbooth.com/articles/focusing-interaction-design-with-design-strategy/)
+- [“Perfecting Your Personas.”](http://www.uie.com/articles/perfecting_personas/) Kim Goodwin.
+- [*Designing for the Digital Age: How to Create Human-Centered Products and Services.*](http://www.amazon.com/Designing-Digital-Age-Human-Centered-Products/dp/0470229101) Kim Goodwin. 
+- [“Inside Goal-Directed Design: A Two-Part Conversation with Alan Cooper.”](http://www.cooper.com/journal/2014/04/inside-goal-directed-design-a-two-part-conversation-with-alan-cooper) Caroline Kraus. 
+- Book available for purchase: [*The Design of Everyday Things.*](http://www.amazon.com/The-Design-Everyday-Things-Expanded/dp/0465050654/) Don Norman. 

--- a/pages/protosketching.md
+++ b/pages/protosketching.md
@@ -34,4 +34,4 @@ No PRA implications. The PRA explicitly exempts direct observation and non-stand
 
 ## Additional resources
 
-[`https://18f.gsa.gov/2015/01/06/protosketch/`](https://18f.gsa.gov/2015/01/06/protosketch/)
+- [“Sketching with code: protosketching.”](https://18f.gsa.gov/2015/01/06/protosketch/) Alan Delevie. 

--- a/pages/prototyping.md
+++ b/pages/prototyping.md
@@ -34,5 +34,4 @@ No PRA implications. The PRA explicitly exempts direct observation and non-stand
 
 ## Additional resources:
 
-- [`http://www.amazon.com/Sketching-User-Experiences-Interactive-Technologies/dp/0123740371`](http://www.amazon.com/Sketching-User-Experiences-Interactive-Technologies/dp/0123740371)
-- [`http://www.uxbooth.com/articles/considering-prototypes/`](http://www.uxbooth.com/articles/considering-prototypes/)
+- [*Sketching User Experiences: Getting the Design Right and the Right Design.*](http://www.amazon.com/Sketching-User-Experiences-Interactive-Technologies/dp/0123740371) Bill Buxton.

--- a/pages/recruiting.md
+++ b/pages/recruiting.md
@@ -41,4 +41,5 @@ If you recruit users who participate for free and aren’t government employees,
 If you do not ask potential participants to respond to a “screener survey,” the PRA does not apply to your recruiting efforts.
 
 ## Additional resources
-* [18F's participant consent form](../assets/downloads/18FResearchParticipantConsentForm.docx), which offers Anti-Deficiency Act-compliant language
+
+- [18F's participant consent form](../assets/downloads/18FResearchParticipantConsentForm.docx), which offers Anti-Deficiency Act-compliant language.

--- a/pages/storyboarding.md
+++ b/pages/storyboarding.md
@@ -33,6 +33,6 @@ To visualize interactions and relationships that might exist between a user and 
 No PRA implications. No information is collected from members of the public.
 
 ## Additional resources:
-- [`http://www.servicedesigntools.org/tools/13`](http://www.servicedesigntools.org/tools/13)
-- [`http://uxmag.com/articles/storyboarding-in-the-software-design-process`](http://uxmag.com/articles/storyboarding-in-the-software-design-process)
-- [`http://www.fastcodesign.com/1672917/the-8-steps-to-creating-a-great-storyboard`](http://www.fastcodesign.com/1672917/the-8-steps-to-creating-a-great-storyboard)
+- Tool: [Communication Methods Supporting Design Processes.](http://www.servicedesigntools.org/tools/13) Service Design Tools. 
+- [“Storyboarding in the Software Design Process.”](http://uxmag.com/articles/storyboarding-in-the-software-design-process) Ambrose Little. 
+- [“The 8 Steps to Creating a Great Storyboard.”](http://www.fastcodesign.com/1672917/the-8-steps-to-creating-a-great-storyboard) Jake Knapp. 

--- a/pages/style-tiles.md
+++ b/pages/style-tiles.md
@@ -32,5 +32,5 @@ No PRA implications. No information is collected from members of the public.
 
 ## Additional resources
 
-- [`http://styletil.es/`](http://styletil.es/)
-- [`http://alistapart.com/article/style-tiles-and-how-they-work`](http://alistapart.com/article/style-tiles-and-how-they-work)
+- Tool: [Style Tiles: A Visual Web Design Process for Clients and the Responsive Web.](http://styletil.es/) Style Tiles. 
+- [“Style Tiles and How They Work.”](http://alistapart.com/article/style-tiles-and-how-they-work) Samantha Warren. 

--- a/pages/task-flow-analysis.md
+++ b/pages/task-flow-analysis.md
@@ -34,5 +34,5 @@ No PRA implications. No information is collected from members of the public.
 
 ## Additional resources:
 
-- [`http://searchenginewatch.com/sew/how-to/2336547/task-analysis-the-key-ux-design-step-everyone-skips`](http://searchenginewatch.com/sew/how-to/2336547/task-analysis-the-key-ux-design-step-everyone-skips)
-- [`http://www.usability.gov/how-to-and-tools/methods/task-analysis.html`](http://www.usability.gov/how-to-and-tools/methods/task-analysis.html)
+- [“Task Analysis: The Key UX Design Step Everyone Skips.”](http://searchenginewatch.com/sew/how-to/2336547/task-analysis-the-key-ux-design-step-everyone-skips) Larry Maine. 
+- Tool: [Task Analysis.](http://www.usability.gov/how-to-and-tools/methods/task-analysis.html) Usability.gov. 

--- a/pages/usability-testing.md
+++ b/pages/usability-testing.md
@@ -34,4 +34,4 @@ No PRA implications. First, any given usability test should involve nine or fewe
 
 ## Additional resources
 
-[`http://www.usabilitybok.org/summative-usability-testing`](http://www.usabilitybok.org/summative-usability-testing)
+- [An explanation of summative usability testing and how to conduct evaluations using this method.](http://www.usabilitybok.org/summative-usability-testing) The Usability Body of Knowledge, a product of the User Experience Professionals’ Association.

--- a/pages/user-scenarios.md
+++ b/pages/user-scenarios.md
@@ -37,5 +37,5 @@ No PRA implications. No information is collected from members of the public.
 
 ## Additional resources
 
-- [`http://www.usability.gov/how-to-and-tools/methods/scenarios.html`](http://www.usability.gov/how-to-and-tools/methods/scenarios.html)
-- [`http://blog.usabilla.com/how-user-scenarios-help-to-improve-your-ux/`](http://blog.usabilla.com/how-user-scenarios-help-to-improve-your-ux/)
+- Tool: [Scenarios.](http://www.usability.gov/how-to-and-tools/methods/scenarios.html) Usability.gov. 
+- [“How User Scenarios Help To Improve Your UX.”](http://blog.usabilla.com/how-user-scenarios-help-to-improve-your-ux/) Sabina Idler.

--- a/pages/visual-preference-testing.md
+++ b/pages/visual-preference-testing.md
@@ -34,5 +34,5 @@ No PRA implications. The PRA explicitly exempts direct observation and non-stand
 
 ## Additional resources
 
-- [`http://www.uxmatters.com/mt/archives/2010/02/rapid-desirability-testing-a-case-study.php`](http://www.uxmatters.com/mt/archives/2010/02/rapid-desirability-testing-a-case-study.php)
-- [`http://www.slideshare.net/pwdoncaster/preference-and-desirability-testing-measuring-emotional-response-to-guide-design`](http://www.slideshare.net/pwdoncaster/preference-and-desirability-testing-measuring-emotional-response-to-guide-design)
+- [Rapid Desirability Testing: A Case Study.](http://www.uxmatters.com/mt/archives/2010/02/rapid-desirability-testing-a-case-study.php) Michael Hawley. 
+- [Preference and Desirability Testing: Measuring Emotional Response to Guide Design.](http://www.slideshare.net/pwdoncaster/preference-and-desirability-testing-measuring-emotional-response-to-guide-design) Michael Hawley and Paul Doncaster. 


### PR DESCRIPTION
## Changes:
- Formatted naked hyperlinks
- Structured resources listings in a more friendly way, so that users would know what they are clicking to.
- Determined we would use only outside, non-18F authored content as resources in the "Additional resources” section. 18F blog posts are ok if we can’t find anything else, but otherwise we should try to steer clear of things written by 18F folks or on sites owned/managed by 18F folks. This resulted in removing a few resources from pages already containing other links.

Thanks to @RyanSibley for the content strategy & editorial lift!

## Review:
@jameshupp 