### PR TITLE
Style fixes to the additional resources update

### DIFF
--- a/pages/affinity-diagramming.md
+++ b/pages/affinity-diagramming.md
@@ -30,5 +30,5 @@ No PRA implications. This method may use data gathered from members of the publi
 
 ## Additional resources
 
-- [An explanation of what affinity diagramming is and how to do it.](http://www.usabilitybok.org/affinity-diagram). The Usability Body of Knowledge, a product of the User Experience Professionals’ Association.
-- [An explanation of affinity diagramming.](http://infodesign.com.au/usabilityresources/affinitydiagramming/). Information and Design.
+- [An explanation of what affinity diagramming is and how to do it.](http://www.usabilitybok.org/affinity-diagram) The Usability Body of Knowledge, a product of the User Experience Professionals’ Association.
+- [An explanation of affinity diagramming.](http://infodesign.com.au/usabilityresources/affinitydiagramming/) Information and Design.

--- a/pages/bodystorming.md
+++ b/pages/bodystorming.md
@@ -35,4 +35,4 @@ To remind participants that interactions are human and physical, to teach stakeh
 
 ## Additional resources
 
-- [An explanation of bodystorming on Wicked Problems Worth Solving.](https://www.wickedproblems.com/6_bodystorming.php) Austin Center for Design.
+[An explanation of bodystorming on Wicked Problems Worth Solving.](https://www.wickedproblems.com/6_bodystorming.php) Austin Center for Design.

--- a/pages/cognitive-walkthrough.md
+++ b/pages/cognitive-walkthrough.md
@@ -36,4 +36,4 @@ To understand whether a design solution is easy for a new or infrequent user to 
 -  If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.
 
 ## Additional resources
-- [An explanation of cognitive walkthroughs and how to conduct one.](http://www.usabilitybok.org/cognitive-walkthrough) The Usability Body of Knowledge, a product of the User Experience Professionals’ Association.
+[An explanation of cognitive walkthroughs and how to conduct one.](http://www.usabilitybok.org/cognitive-walkthrough) The Usability Body of Knowledge, a product of the User Experience Professionals’ Association.

--- a/pages/content-audit.md
+++ b/pages/content-audit.md
@@ -40,5 +40,5 @@ To identify content that needs to be revised in new versions of a website. Conte
 No PRA implications. No information is collected from members of the public.
 
 ## Additional resources
-- [“How to Conduct a Content Audit.”](http://uxmastery.com/how-to-conduct-a-content-audit/). UX Mastery.
-- [“Auditing Big Sites Doesn’t Have to Be Taxing.”](http://blog.braintraffic.com/2012/04/auditing-big-sites-doesn%E2%80%99t-have-to-be-taxing/). Christine Anameier.
+- [“How to Conduct a Content Audit.”](http://uxmastery.com/how-to-conduct-a-content-audit/) UX Mastery.
+- [“Auditing Big Sites Doesn’t Have to Be Taxing.”](http://blog.braintraffic.com/2012/04/auditing-big-sites-doesn%E2%80%99t-have-to-be-taxing/) Christine Anameier.

--- a/pages/design-principles.md
+++ b/pages/design-principles.md
@@ -36,4 +36,4 @@ No PRA implications. Generally, no information is collected from members of the 
 
 ## Additional resources
 
-- [“Design Principles: Dominance, Focal Points And Hierarchy.”](http://www.smashingmagazine.com/2015/02/27/design-principles-dominance-focal-points-hierarchy/) Steven Bradley. 
+[“Design Principles: Dominance, Focal Points And Hierarchy.”](http://www.smashingmagazine.com/2015/02/27/design-principles-dominance-focal-points-hierarchy/) Steven Bradley. 

--- a/pages/design-studio.md
+++ b/pages/design-studio.md
@@ -38,5 +38,5 @@ No PRA implications. If conducted with nine or fewer members of the public, the 
 
 ## Additional resources
 
-- A [presentation by Todd Zaki Warfel.](https://vimeo.com/37861987/)
+A [presentation by Todd Zaki Warfel.](https://vimeo.com/37861987/)
  explaining what Design Studio is. Todd Zaki Warfel.

--- a/pages/kj-method.md
+++ b/pages/kj-method.md
@@ -40,7 +40,7 @@ Likely no PRA implications: generally any given session is likely to have nine o
 
 ## Additional resources
 
-- [“The KJ-Technique: A Group Process for Establishing Priorities.”](http://www.uie.com/articles/kj_technique/) Jared M. Spool. 
+[“The KJ-Technique: A Group Process for Establishing Priorities.”](http://www.uie.com/articles/kj_technique/) Jared M. Spool. 
 
 ## Example from 18F
 

--- a/pages/metrics-definition.md
+++ b/pages/metrics-definition.md
@@ -34,8 +34,7 @@ No PRA implications. No information is collected from members of the public.
 
 ## Additional resources
 
-- [“Needs + Resources + Location + Schedule + Budget = Scope.”](http://www.uxmatters.com/mt/archives/2009/12/needs-resources-location-schedule-budget-scope.php). Whitney Hess.
-- [“No One Nos: Learning to Say No to Bad Ideas.”](http://alistapart.com/article/no-one-nos-learning-to-say-no-to-bad-ideas). Whitney Hess.
-- Video: [Understanding Impact: The mySociety agenda.](https://www.youtube.com/watch?v=oAU0c7ocZKs). Dr. Rebecca Rumbul.
-- [“How not to say the wrong thing”](http://articles.latimes.com/2013/apr/07/opinion/la-oe-0407-silk-ring-theory-20130407). Susan Silk and Barry Goldman.
-
+- [“Needs + Resources + Location + Schedule + Budget = Scope.”](http://www.uxmatters.com/mt/archives/2009/12/needs-resources-location-schedule-budget-scope.php) Whitney Hess.
+- [“No One Nos: Learning to Say No to Bad Ideas.”](http://alistapart.com/article/no-one-nos-learning-to-say-no-to-bad-ideas) Whitney Hess.
+- Video: [Understanding Impact: The mySociety agenda.](https://www.youtube.com/watch?v=oAU0c7ocZKs) Dr. Rebecca Rumbul.
+- [“How not to say the wrong thing”](http://articles.latimes.com/2013/apr/07/opinion/la-oe-0407-silk-ring-theory-20130407) Susan Silk and Barry Goldman.

--- a/pages/protosketching.md
+++ b/pages/protosketching.md
@@ -34,4 +34,4 @@ No PRA implications. The PRA explicitly exempts direct observation and non-stand
 
 ## Additional resources
 
-- [“Sketching with code: protosketching.”](https://18f.gsa.gov/2015/01/06/protosketch/) Alan Delevie. 
+[“Sketching with code: protosketching.”](https://18f.gsa.gov/2015/01/06/protosketch/) Alan Delevie. 

--- a/pages/prototyping.md
+++ b/pages/prototyping.md
@@ -34,4 +34,4 @@ No PRA implications. The PRA explicitly exempts direct observation and non-stand
 
 ## Additional resources:
 
-- [*Sketching User Experiences: Getting the Design Right and the Right Design.*](http://www.amazon.com/Sketching-User-Experiences-Interactive-Technologies/dp/0123740371) Bill Buxton.
+[*Sketching User Experiences: Getting the Design Right and the Right Design.*](http://www.amazon.com/Sketching-User-Experiences-Interactive-Technologies/dp/0123740371) Bill Buxton.

--- a/pages/usability-testing.md
+++ b/pages/usability-testing.md
@@ -34,4 +34,4 @@ No PRA implications. First, any given usability test should involve nine or fewe
 
 ## Additional resources
 
-- [An explanation of summative usability testing and how to conduct evaluations using this method.](http://www.usabilitybok.org/summative-usability-testing) The Usability Body of Knowledge, a product of the User Experience Professionals’ Association.
+[An explanation of summative usability testing and how to conduct evaluations using this method.](http://www.usabilitybok.org/summative-usability-testing) The Usability Body of Knowledge, a product of the User Experience Professionals’ Association.


### PR DESCRIPTION
## Changes
- Removed hyphens when there was only one resource
- Removed duplicate periods from affinity diagramming, content audit,
and metrics definition

## Review
@jenniferthibault 
@RyanSibley 

## Notes
If Ryan can confirm that the second bullet brings it into line with the original formatting, Jen you should be able to merge this into your branch and then we can pull the whole thing into staging.