### PR TITLE
Remove sudo: true from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: true
 language: ruby
 rvm:
 - 2.1


### PR DESCRIPTION
`sudo` may not be necessary and removing it could speed up travis builds.