### PR TITLE
correct typo in PRA references

### DIFF
--- a/pages/bodystorming.md
+++ b/pages/bodystorming.md
@@ -30,7 +30,7 @@ To remind participants that interactions are human and physical, to teach stakeh
 
 ## Applied in government research:
 
-- No PRA implications. Even when users are present, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.5(h)3.
+- No PRA implications. Even when users are present, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3.
 - If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.
 
 ## Additional resources

--- a/pages/card-sorting.md
+++ b/pages/card-sorting.md
@@ -40,4 +40,4 @@ There are two types of card sorting: open and closed. Most card sorts are perfor
 
 ## Applied in government research
 
-No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.5(h)3. It also explicitly excludes tests of knowledge or aptitude, 5 CFR 1320.5(h)7, which is essentially what a card sort tests (though in our case, a poor result is our fault).
+No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. It also explicitly excludes tests of knowledge or aptitude, 5 CFR 1320.3(h)7, which is essentially what a card sort tests (though in our case, a poor result is our fault).

--- a/pages/cognitive-walkthrough.md
+++ b/pages/cognitive-walkthrough.md
@@ -32,7 +32,7 @@ To understand whether a design solution is easy for a new or infrequent user to 
 
 ## Applied in government research
 
--  No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey) that a cognitive walkthrough entails, 5 CFR 1320.5(h)3.
+-  No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey) that a cognitive walkthrough entails, 5 CFR 1320.3(h)3.
 -  If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.
 
 ## Additional resources

--- a/pages/contextual-inquiry.md
+++ b/pages/contextual-inquiry.md
@@ -28,7 +28,7 @@ To learn how and why users do what they do; to discover needs and attitudes that
 
 ## Applied in government research
 
-- No PRA implications, if done properly. Contextual interviews should be non-standardized, conversational, and based on observation. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.5(h)3. See the methods for [Recruiting](../recruiting/) and [Privacy](../privacy/) for more tips on taking input from the public.
+- No PRA implications, if done properly. Contextual interviews should be non-standardized, conversational, and based on observation. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](../recruiting/) and [Privacy](../privacy/) for more tips on taking input from the public.
 - For internal folks, get permission from the right level of management. If participants could be under union agreements, contact the agency’s labor relations team.
 
 ## Example from 18F

--- a/pages/design-principles.md
+++ b/pages/design-principles.md
@@ -32,7 +32,7 @@ To give the team and the stakeholders a shared point of reference when negotiati
 
 ## Applied in government research
 
-No PRA implications. Generally, no information is collected from members of the public. Even when stakeholders are members of the public, the PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey), 5 CFR 1320.5(h)3. See the methods for [Recruiting](../recruiting/) and [Privacy](../privacy) for more tips on taking input from the public.
+No PRA implications. Generally, no information is collected from members of the public. Even when stakeholders are members of the public, the PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey), 5 CFR 1320.3(h)3. See the methods for [Recruiting](../recruiting/) and [Privacy](../privacy) for more tips on taking input from the public.
 
 ## Additional resources
 

--- a/pages/journey-mapping.md
+++ b/pages/journey-mapping.md
@@ -33,7 +33,7 @@ You can also map user journeys as part of a workshop with stakeholders, similar 
 
 ## Applied in government research
 
-No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.5(h)3. See the methods for [Recruiting](../recruiting/) and [Privacy](../privacy/) for more tips on taking input from the public.
+No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](../recruiting/) and [Privacy](../privacy/) for more tips on taking input from the public.
 
 ## Additional resources
 

--- a/pages/protosketching.md
+++ b/pages/protosketching.md
@@ -30,7 +30,7 @@ To stimulate stakeholder imaginations and focus discussion on issues about data,
 
 ## Applied in government research
 
-No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.5(h)3.
+No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3.
 
 ## Additional resources
 

--- a/pages/prototyping.md
+++ b/pages/prototyping.md
@@ -30,7 +30,7 @@ To enable direct examination of a design concept’s viability with a number of 
 
 ## Applied in government research
 
-No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.5(h)3. See the methods for [Recruiting](../recruiting/) and [Privacy](../privacy/) for more tips on taking input from the public.
+No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](../recruiting/) and [Privacy](../privacy/) for more tips on taking input from the public.
 
 ## Additional resources:
 

--- a/pages/stakeholder-and-user-interviews.md
+++ b/pages/stakeholder-and-user-interviews.md
@@ -29,4 +29,4 @@ To build consensus about the problem statement and research objectives.
 
 ## Applied in government research
 
-No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.5(h)3. See the methods for [Recruiting](../recruiting/) and [Privacy](../privacy/) for more tips on taking input from the public.
+No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](../recruiting/) and [Privacy](../privacy/) for more tips on taking input from the public.

--- a/pages/usability-testing.md
+++ b/pages/usability-testing.md
@@ -30,7 +30,7 @@ To learn a given design’s challenges, opportunities, and successes.
 
 ## Applied in government research
 
-No PRA implications. First, any given usability test should involve nine or fewer users. Additionally, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.5(h)3. It also specifically excludes tests of knowledge or aptitude, 5 CFR 1320.5(h)7, which is essentially what a usability test tests. See the methods for [Recruiting](../recruiting/) and [Privacy](../privacy/) for more tips on taking input from the public.
+No PRA implications. First, any given usability test should involve nine or fewer users. Additionally, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. It also specifically excludes tests of knowledge or aptitude, 5 CFR 1320.3(h)7, which is essentially what a usability test tests. See the methods for [Recruiting](../recruiting/) and [Privacy](../privacy/) for more tips on taking input from the public.
 
 ## Additional resources
 

--- a/pages/visual-preference-testing.md
+++ b/pages/visual-preference-testing.md
@@ -30,7 +30,7 @@ To align the established branding guidelines and attributes of a solution with t
 
 ## Applied in government research
 
-No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.5(h)3. See the methods for [Recruiting](../recruiting/) and [Privacy](../privacy/) for more tips on taking input from the public.
+No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](../recruiting/) and [Privacy](../privacy/) for more tips on taking input from the public.
 
 ## Additional resources
 


### PR DESCRIPTION
Changed 5 CFR 1320.5(h)3 and 5 CFR 1320.5(h)7 to 5 CFR 1320.3(h)3 and 5 CFR 1320.3(h)7 (changed .5 to .3 in two places)