### PR TITLE
fix body copy URLs with Jekyll-y prepended URLs

### DIFF
--- a/_pages/decide/affinity-diagramming.md
+++ b/_pages/decide/affinity-diagramming.md
@@ -17,7 +17,7 @@ To draw out insights from qualitative data quickly and collaboratively.
 
 ## How to do it
 
-1. Record ideas, quotes, or observations from [interviews](/../discover/stakeholder-and-user-interviews/), [contextual inquiry](/../discover/contextual-inquiry/), or other sources of research on Post-It notes.
+1. Record ideas, quotes, or observations from [interviews]({{ '/discover/stakeholder-and-user-interviews/' | prepend: site.baseurl }}), [contextual inquiry]({{ '/discover/contextual-inquiry/' | prepend: site.baseurl }}), or other sources of research on Post-It notes.
 
 2. Place the Post-It notes on a white board (in no particular arrangement). Move the Post-It notes into related groups.
 

--- a/_pages/decide/design-principles.md
+++ b/_pages/decide/design-principles.md
@@ -31,7 +31,7 @@ To give the team and the stakeholders a shared point of reference when negotiati
 
 ## Applied in government research
 
-No PRA implications. Generally, no information is collected from members of the public. Even when stakeholders are members of the public, the PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey), 5 CFR 1320.3(h)3. See the methods for [Recruiting](/../fundamentals/recruiting/) and [Privacy](/../fundamentals/privacy) for more tips on taking input from the public.
+No PRA implications. Generally, no information is collected from members of the public. Even when stakeholders are members of the public, the PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey), 5 CFR 1320.3(h)3. See the methods for [Recruiting]({{ '/fundamentals/recruiting' | prepend: site.baseurl }}) and [Privacy](/../fundamentals/privacy) for more tips on taking input from the public.
 
 ## Additional resources
 

--- a/_pages/decide/journey-mapping.md
+++ b/_pages/decide/journey-mapping.md
@@ -24,15 +24,15 @@ To provide design teams with a bird’s-eye view of a design system, helping the
  - Discrete moments or major decisions they make
  - The emotions associated with these moments or decisions
 
-2. Visualize the order in which people exhibit behaviors, use information, make decisions, and feel emotions. Group elements into a table of “phases” related to the personal narrative of each [persona](/../decide/personas/). Identify where personas share contextual components.
+2. Visualize the order in which people exhibit behaviors, use information, make decisions, and feel emotions. Group elements into a table of “phases” related to the personal narrative of each [persona]({{ '/decide/personas/' | prepend: site.baseurl }}). Identify where personas share contextual components.
 
-3. Discuss the map with stakeholders. Point out insights it offers. Use these insights to establish [design principles](/../decide/design-principles/). Think about how to collapse or accelerate a customer’s journey through the various phases. Incorporate this information into the project’s scope.
+3. Discuss the map with stakeholders. Point out insights it offers. Use these insights to establish [design principles]({{ '/decide/design-principles/' | prepend: site.baseurl }}). Think about how to collapse or accelerate a customer’s journey through the various phases. Incorporate this information into the project’s scope.
 
-You can also map user journeys as part of a workshop with stakeholders, similar to a [design studio](/../discover/design-studio/).
+You can also map user journeys as part of a workshop with stakeholders, similar to a [design studio]({{ '/discover/design-studio/' | prepend: site.baseurl }}).
 
 ## Applied in government research
 
-No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](/../fundamentals/recruiting/) and [Privacy](/../fundamentals/privacy/) for more tips on taking input from the public.
+No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting]({{ '/fundamentals/recruiting' | prepend: site.baseurl }}) and [Privacy]({{ '/fundamentals/privacy' | prepend: site.baseurl }}) for more tips on taking input from the public.
 
 ## Additional resources
 

--- a/_pages/decide/personas.md
+++ b/_pages/decide/personas.md
@@ -17,7 +17,7 @@ To ground design in reality by forcing us to consider the goals, behaviors, and 
 
 ## How to do it
 
-1. Gather research from earlier activities like [contextual inquiry](/../discover/contextual-inquiry/) or [stakeholder interviews](../stakeholder-and-user-interviews) in a way that’s easy to review. You can create placeholder personas without research to teach user-centered thinking about users. But because they are effectively stereotypes, avoid using them for implementable design decisions.
+1. Gather research from earlier activities like [contextual inquiry]({{ '/discover/contextual-inquiry/' | prepend: site.baseurl }}) or [stakeholder interviews](../stakeholder-and-user-interviews) in a way that’s easy to review. You can create placeholder personas without research to teach user-centered thinking about users. But because they are effectively stereotypes, avoid using them for implementable design decisions.
 
 2. Create a set of user archetypes based on how you believe people will use your solution. These typically get titles (for example, “data administrators” rather than “those who submit data”).
 

--- a/_pages/decide/site-mapping.md
+++ b/_pages/decide/site-mapping.md
@@ -9,7 +9,7 @@ A comprehensive rendering of how a website’s pages relate to one another.
 
 ## Reasons to use it
 
-To audit an existing website by assessing its structure and content. Site maps also help you plan and organize the contents of a new website prior to [wireframing](/../make/wireframing/) and building it.
+To audit an existing website by assessing its structure and content. Site maps also help you plan and organize the contents of a new website prior to [wireframing]({{ '/make/wireframing/' | prepend: site.baseurl }}) and building it.
 
 ## Time required
 

--- a/_pages/decide/storyboarding.md
+++ b/_pages/decide/storyboarding.md
@@ -17,7 +17,7 @@ To visualize interactions and relationships that might exist between a user and 
 
 ## How to do it
 
-1. Gather any documents that describe the different use cases or [scenarios](/../decide/user-scenarios/) in which users will interact with the solution.
+1. Gather any documents that describe the different use cases or [scenarios]({{ '/decide/user-scenarios/' | prepend: site.baseurl }}) in which users will interact with the solution.
 
 2. Sketch scenes that visually depict a user interacting with a solution, including as much context as possible. For example: Are they on the move? Where are they? What else is in their environment?
 

--- a/_pages/decide/user-scenarios.md
+++ b/_pages/decide/user-scenarios.md
@@ -28,7 +28,7 @@ To remind a team, during both the design and validation phases, of the overarchi
 
 4. Share with the full team for feedback and refinement.
 
-5. If you want to use the scenarios for [usability testing](/../validate/usability-testing/), write them so they do not lead the participant to the correct outcome.
+5. If you want to use the scenarios for [usability testing]({{ '/validate/usability-testing' | prepend: site.baseurl }}), write them so they do not lead the participant to the correct outcome.
 
 ## Applied in government research
 

--- a/_pages/discover/bodystorming.md
+++ b/_pages/discover/bodystorming.md
@@ -21,7 +21,7 @@ To remind participants that interactions are human and physical, to teach stakeh
 
 2. Bring the project team to the user’s environment. If that’s not practical, model the user’s environment in a conference room.
 
-3. Assign each member of the project team to a role, interface, or “touchpoint” that you have identified in a [journey map](/../decide/journey-mapping/). If users are present, ask them to pretend to accomplish their goals as usual. Otherwise, assign a [persona](/../decide/personas/) to each member of the product team who isn’t serving as a touchpoint. If you anticipate discomfort, assign roles in advance and start with a basic script.
+3. Assign each member of the project team to a role, interface, or “touchpoint” that you have identified in a [journey map]({{ '/decide/journey-mapping/' | prepend: site.baseurl }}). If users are present, ask them to pretend to accomplish their goals as usual. Otherwise, assign a [persona]({{ '/decide/personas/' | prepend: site.baseurl }}) to each member of the product team who isn’t serving as a touchpoint. If you anticipate discomfort, assign roles in advance and start with a basic script.
 
 4. Use props to role play how users accomplish their goals. “Speak the interface” to one another. For example, one of the touchpoints might say “Submit all of your required forms,” and the user might respond “Arg! I don’t know what forms are required!”
 

--- a/_pages/discover/contextual-inquiry.md
+++ b/_pages/discover/contextual-inquiry.md
@@ -9,7 +9,7 @@ The product team unobtrusively observes participants at work, with their permiss
 
 ## Reasons to use it
 
-To learn how and why users do what they do; to discover needs and attitudes that might not emerge in an [interview](/../discover/stakeholder-and-user-interviews/); to map how tools, digital and otherwise, interact during complex activities.
+To learn how and why users do what they do; to discover needs and attitudes that might not emerge in an [interview]({{ '/discover/stakeholder-and-user-interviews/' | prepend: site.baseurl }}); to map how tools, digital and otherwise, interact during complex activities.
 
 ## Time required
 
@@ -27,7 +27,7 @@ To learn how and why users do what they do; to discover needs and attitudes that
 
 ## Applied in government research
 
-- No PRA implications, if done properly. Contextual interviews should be non-standardized, conversational, and based on observation. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](/../fundamentals/recruiting/) and [Privacy](/../fundamentals/privacy/) for more tips on taking input from the public.
+- No PRA implications, if done properly. Contextual interviews should be non-standardized, conversational, and based on observation. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting]({{ '/fundamentals/recruiting' | prepend: site.baseurl }}) and [Privacy]({{ '/fundamentals/privacy' | prepend: site.baseurl }}) for more tips on taking input from the public.
 - For internal folks, get permission from the right level of management. If participants could be under union agreements, contact the agency’s labor relations team.
 
 ## Example from 18F

--- a/_pages/discover/design-studio.md
+++ b/_pages/discover/design-studio.md
@@ -17,7 +17,7 @@ To create a shared understanding and appreciation of design problems confronting
 
 ## How to do it
 
-1. Invite between six and 12 participants: stakeholders, users, and team members who need to build a shared understanding. Provide the design prompt for the session ahead of time. Share applicable research already conducted. Unless users will be present, share [personas](/../decide/personas/) summarizing what users are trying to do and why.
+1. Invite between six and 12 participants: stakeholders, users, and team members who need to build a shared understanding. Provide the design prompt for the session ahead of time. Share applicable research already conducted. Unless users will be present, share [personas]({{ '/decide/personas/' | prepend: site.baseurl }}) summarizing what users are trying to do and why.
 
 2. Bring drawing materials. At the start of the meeting, review the design prompt and research you shared.
 

--- a/_pages/discover/feature-dot-voting.md
+++ b/_pages/discover/feature-dot-voting.md
@@ -33,5 +33,5 @@ To build group consensus quickly from the priorities of individual in the group.
 
 ## Applied in government research
 
-No PRA implications: feature dot voting falls under "direct observation", which is explicitly exempt from the PRA, 5 CFR 1320(h)3. See the methods for [Recruiting](/../fundamentals/recruiting/) and [Privacy](/../fundamentals/privacy/) for more tips on taking input from the public.
+No PRA implications: feature dot voting falls under "direct observation", which is explicitly exempt from the PRA, 5 CFR 1320(h)3. See the methods for [Recruiting]({{ '/fundamentals/recruiting' | prepend: site.baseurl }}) and [Privacy]({{ '/fundamentals/privacy' | prepend: site.baseurl }}) for more tips on taking input from the public.
 

--- a/_pages/discover/heuristic-analysis.md
+++ b/_pages/discover/heuristic-analysis.md
@@ -28,7 +28,7 @@ To quickly identify common design problems that make websites hard to use withou
 
 ## Applied in government research
 
-No PRA Implications, as heuristic evaluations usually include a small number of evaluators. If conducted with nine or fewer members of the public, the PRA does not apply, 5 CFR 1320.5(c)4. If participants are employees, the PRA does not apply. See the methods for [Recruiting](/../fundamentals/recruiting/) and [Privacy](/../fundamentals/privacy/) for more tips on taking input from the public.
+No PRA Implications, as heuristic evaluations usually include a small number of evaluators. If conducted with nine or fewer members of the public, the PRA does not apply, 5 CFR 1320.5(c)4. If participants are employees, the PRA does not apply. See the methods for [Recruiting]({{ '/fundamentals/recruiting' | prepend: site.baseurl }}) and [Privacy]({{ '/fundamentals/privacy' | prepend: site.baseurl }}) for more tips on taking input from the public.
 
 ## Additional resources
 

--- a/_pages/discover/metrics-definition.md
+++ b/_pages/discover/metrics-definition.md
@@ -19,7 +19,7 @@ To keep the team vigilant about the user’s perspective and to establish a user
 
 1. Describe the existing situation to the team, including who the stakeholders are and what their stake is.
 
-2. Use [personas](/../decide/personas/) to identify users’ skills, practices, and behaviors. Decide which you want to promote (and how you would measure that). Next, look at personas’ pain points and consider how you would alleviate them (and how you would measure that).
+2. Use [personas]({{ '/decide/personas/' | prepend: site.baseurl }}) to identify users’ skills, practices, and behaviors. Decide which you want to promote (and how you would measure that). Next, look at personas’ pain points and consider how you would alleviate them (and how you would measure that).
 
 3. Anonymously collect the team’s greatest hopes and fears. Print these out, group them by topic, and discuss. Think about how you can measure throughout the project whether it is aligning with your collective hopes or deviating toward your collective fears.
 

--- a/_pages/discover/stakeholder-and-user-interviews.md
+++ b/_pages/discover/stakeholder-and-user-interviews.md
@@ -20,7 +20,7 @@ To build consensus about the problem statement and research objectives.
 1. Come to the interview with a guide for yourself of some areas you’d like to ask about, and some specific questions as a back up. Questions will often concern the individual’s role, the organization, the individuals’ needs, and metrics for success of the project. Possible starters:
  - &ldquo;What did you do yesterday?&rdquo;
  - Ask lots of &ldquo;why is that&rdquo; and &ldquo;how do you do that&rdquo; questions.
- - If there are other products they use or your product doesn’t have constraints imposed by prior work, observe the stakeholders using a [competing product](/../decide/comparative-analysis/).
+ - If there are other products they use or your product doesn’t have constraints imposed by prior work, observe the stakeholders using a [competing product]({{ '/decide/comparative-analysis/' | prepend: site.baseurl }}).
 
 2. Sit down one-on-one with the participant, or two-on-one with a note-taker or joint interviewer, in a focused environment. Introduce yourself. Explain the premise for the interview as far as you can without biasing their responses.
 
@@ -28,4 +28,4 @@ To build consensus about the problem statement and research objectives.
 
 ## Applied in government research
 
-No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](/../fundamentals/recruiting/) and [Privacy](/../fundamentals/privacy/) for more tips on taking input from the public.
+No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting]({{ '/fundamentals/recruiting' | prepend: site.baseurl }}) and [Privacy]({{ '/fundamentals/privacy' | prepend: site.baseurl }}) for more tips on taking input from the public.

--- a/_pages/make/prototyping.md
+++ b/_pages/make/prototyping.md
@@ -17,7 +17,7 @@ To enable direct examination of a design concept’s viability with a number of 
 
 ## How to do it
 
-1. Create a rudimentary version of your product. It can be static or functional. Think in the same way you would about a [wireframe](/../make/wireframing/): demonstrate structure and relationships among different elements, but don’t worry about stylized elements.
+1. Create a rudimentary version of your product. It can be static or functional. Think in the same way you would about a [wireframe]({{ '/make/wireframing/' | prepend: site.baseurl }}): demonstrate structure and relationships among different elements, but don’t worry about stylized elements.
 
 2. Give the prototype to the user and observe their interactions without instruction.
 
@@ -29,7 +29,7 @@ To enable direct examination of a design concept’s viability with a number of 
 
 ## Applied in government research
 
-No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](/../fundamentals/recruiting/) and [Privacy](/../fundamentals/privacy/) for more tips on taking input from the public.
+No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting]({{ '/fundamentals/recruiting' | prepend: site.baseurl }}) and [Privacy]({{ '/fundamentals/privacy' | prepend: site.baseurl }}) for more tips on taking input from the public.
 
 ## Additional resources:
 

--- a/_pages/make/wireframing.md
+++ b/_pages/make/wireframing.md
@@ -21,7 +21,7 @@ To prioritize information (substance and relationships) over decoration (style) 
 
 2. Use this opportunity to start listing what UX/UI patterns you will need.
 
-3. Review your wireframes with specific [user scenarios](/../decide/user-scenarios/) and [personas](/../decide/personas/) in mind. Can users accomplish their task with the wireframe you are sketching out?
+3. Review your wireframes with specific [user scenarios]({{ '/decide/user-scenarios/' | prepend: site.baseurl }}) and [personas]({{ '/decide/personas/' | prepend: site.baseurl }}) in mind. Can users accomplish their task with the wireframe you are sketching out?
 
 4. Use the wireframes to get the team’s feedback on feasibility and structure.
 

--- a/_pages/validate/multivariate-testing.md
+++ b/_pages/validate/multivariate-testing.md
@@ -19,7 +19,7 @@ To incorporate different contexts, channels, or user types into addressing a use
 
 1. Identify the call to action, content section, or feature that needs to be improved to increase conversion rates or user engagement.
 
-2. Develop a list of possible issues that may be hurting conversion rates or engagement. Specify in advance what you are optimizing for (possibly through [metrics definition](/../discover/metrics-definition/)).
+2. Develop a list of possible issues that may be hurting conversion rates or engagement. Specify in advance what you are optimizing for (possibly through [metrics definition]({{ '/discover/metrics-definition/' | prepend: site.baseurl }})).
 
 3. Design several solutions that aim to address the issues listed. Each solution should attempt to address every issue by using a unique combination of variants so each solution can be compared fairly.
 
@@ -29,7 +29,7 @@ To incorporate different contexts, channels, or user types into addressing a use
 
 ## Applied in government research
 
-No PRA implications. No one asks the users questions, so the PRA does not apply. See the methods for [Recruiting](/../fundamentals/recruiting/) and [Privacy](../privacy) for more tips on taking input from the public.
+No PRA implications. No one asks the users questions, so the PRA does not apply. See the methods for [Recruiting]({{ '/fundamentals/recruiting' | prepend: site.baseurl }}) and [Privacy](../privacy) for more tips on taking input from the public.
 
 ## Additional resources
 

--- a/_pages/validate/usability-testing.md
+++ b/_pages/validate/usability-testing.md
@@ -17,11 +17,11 @@ To learn a given design’s challenges, opportunities, and successes.
 
 ## How to do it
 
-1. [Create a prototype](/../make/prototyping/) that sufficiently conveys the team’s hypothesis based on research. In the absence of a prototype, consider testing a [competitor’s product](/../decide/comparative-analysis/).
+1. [Create a prototype](/../make/prototyping/) that sufficiently conveys the team’s hypothesis based on research. In the absence of a prototype, consider testing a [competitor’s product]({{ '/decide/comparative-analysis/' | prepend: site.baseurl }}).
 
 2. Stage a scenario in which someone who would actually use your product tries to employ the prototype for their own ends. Record their attempt. Optionally:
  - Ask users to think out loud as they try.
- - [Compensate the participant](/../fundamentals/incentives/) for their time.
+ - [Compensate the participant]({{ '/fundamentals/incentives' | prepend: site.baseurl }}) for their time.
 
 3. Avoid asking participants to perform tasks far outside their normal context. This will lead them to reflect on the design rather than their ability to accomplish their goals. (For example, to test a new layout for a “user account” section on a voter registration website, recruit only people who already register to vote online.)
 
@@ -29,7 +29,7 @@ To learn a given design’s challenges, opportunities, and successes.
 
 ## Applied in government research
 
-No PRA implications. First, any given usability test should involve nine or fewer users. Additionally, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. It also specifically excludes tests of knowledge or aptitude, 5 CFR 1320.3(h)7, which is essentially what a usability test tests. See the methods for [Recruiting](/../fundamentals/recruiting/) and [Privacy](/../fundamentals/privacy/) for more tips on taking input from the public.
+No PRA implications. First, any given usability test should involve nine or fewer users. Additionally, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. It also specifically excludes tests of knowledge or aptitude, 5 CFR 1320.3(h)7, which is essentially what a usability test tests. See the methods for [Recruiting]({{ '/fundamentals/recruiting' | prepend: site.baseurl }}) and [Privacy]({{ '/fundamentals/privacy' | prepend: site.baseurl }}) for more tips on taking input from the public.
 
 ## Additional resources
 

--- a/_pages/validate/visual-preference-testing.md
+++ b/_pages/validate/visual-preference-testing.md
@@ -13,7 +13,7 @@ To align the established branding guidelines and attributes of a solution with t
 
 ## Time required
 
-**Medium:** 4-12 hours for mood boards or [style tiles](/../decide/style-tiles/). 30 minutes per participant to get feedback.
+**Medium:** 4-12 hours for mood boards or [style tiles]({{ '/decide/style-tiles/' | prepend: site.baseurl }}). 30 minutes per participant to get feedback.
 
 ## How to do it
 
@@ -29,7 +29,7 @@ To align the established branding guidelines and attributes of a solution with t
 
 ## Applied in government research
 
-No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](/../fundamentals/recruiting/) and [Privacy](/../fundamentals/privacy/) for more tips on taking input from the public.
+No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting]({{ '/fundamentals/recruiting' | prepend: site.baseurl }}) and [Privacy]({{ '/fundamentals/privacy' | prepend: site.baseurl }}) for more tips on taking input from the public.
 
 ## Additional resources
 


### PR DESCRIPTION
Change format for all body copy URLs (excluding index/category pages) from `[competing product](/../decide/comparative-analysis/)` format to `[competing product]({{ '/discover/whatever' | prepend: site.baseurl }})` format, so that URLs will work locally and on staging, and (fingers severely crossed) even on production!

