### PR TITLE
Add redirection, fixes #112

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'jekyll'
 gem 'redcarpet'
 gem 'rouge'
 gem 'go_script'
+gem 'jekyll-redirect-from'
 
 group :jekyll_plugins do
   gem 'guides_style_18f'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,8 @@ GEM
       mercenary (~> 0.3.3)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
+    jekyll-redirect-from (0.11.0)
+      jekyll (>= 2.0)
     jekyll-sass-converter (1.4.0)
       sass (~> 3.4)
     jekyll-watch (1.4.0)
@@ -53,6 +55,7 @@ DEPENDENCIES
   go_script
   guides_style_18f
   jekyll
+  jekyll-redirect-from
   redcarpet
   rouge
 

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,9 @@ exclude:
 - README.md
 - go
 
+gems:
+  - jekyll-redirect-from
+
 permalink: pretty
 highlighter: rouge
 

--- a/_pages/decide/affinity-diagramming.md
+++ b/_pages/decide/affinity-diagramming.md
@@ -1,6 +1,7 @@
 ---
 title: Affinity diagramming
 parent: Decide
+redirect_from: /affinity-diagramming/
 ---
 
 ## What it is

--- a/_pages/decide/comparative-analysis.md
+++ b/_pages/decide/comparative-analysis.md
@@ -1,6 +1,7 @@
 ---
 title: Comparative analysis
 parent: Decide
+redirect_from: /comparative-analysis/
 ---
 
 ## What it is

--- a/_pages/decide/content-audit.md
+++ b/_pages/decide/content-audit.md
@@ -1,6 +1,7 @@
 ---
 title: Content audit
 parent: Decide
+redirect_from: /content-audit/
 ---
 
 ## What it is

--- a/_pages/decide/design-principles.md
+++ b/_pages/decide/design-principles.md
@@ -1,6 +1,7 @@
 ---
 title: Design principles
 parent: Decide
+redirect_from: /design-principles/
 ---
 
 ## What it is
@@ -35,4 +36,4 @@ No PRA implications. Generally, no information is collected from members of the 
 
 ## Additional resources
 
-[“Design Principles: Dominance, Focal Points And Hierarchy.”](http://www.smashingmagazine.com/2015/02/27/design-principles-dominance-focal-points-hierarchy/) Steven Bradley. 
+[“Design Principles: Dominance, Focal Points And Hierarchy.”](http://www.smashingmagazine.com/2015/02/27/design-principles-dominance-focal-points-hierarchy/) Steven Bradley.

--- a/_pages/decide/journey-mapping.md
+++ b/_pages/decide/journey-mapping.md
@@ -1,6 +1,7 @@
 ---
 title: Journey mapping
 parent: Decide
+redirect_from: /journey-mapping/
 ---
 
 ## What it is

--- a/_pages/decide/mental-modeling.md
+++ b/_pages/decide/mental-modeling.md
@@ -1,6 +1,7 @@
 ---
 title: Mental modeling
 parent: Decide
+redirect_from: /mental-models/
 ---
 
 ## What it is
@@ -31,5 +32,5 @@ No PRA implications. No information is collected from members of the public.
 
 ## Additional resources
 
-- Book available for purchase: [*Mental Models: Aligning Design Strategy with Human Behavior.*](http://rosenfeldmedia.com/books/mental-models/) Indi Young. 
+- Book available for purchase: [*Mental Models: Aligning Design Strategy with Human Behavior.*](http://rosenfeldmedia.com/books/mental-models/) Indi Young.
 - [“The Secret to Designing an Intuitive UX : Match the Mental Model to the Conceptual Model.”](http://uxmag.com/articles/the-secret-to-designing-an-intuitive-user-experience) Susan Weinschenk, UX Magazine.

--- a/_pages/decide/personas.md
+++ b/_pages/decide/personas.md
@@ -1,6 +1,7 @@
 ---
 title: Personas
 parent: Decide
+redirect_from: /personas/
 ---
 
 ## What it is
@@ -34,6 +35,6 @@ No PRA implications. No information is collected from members of the public.
 ## Additional resources
 
 - [“Perfecting Your Personas.”](http://www.uie.com/articles/perfecting_personas/) Kim Goodwin.
-- [*Designing for the Digital Age: How to Create Human-Centered Products and Services.*](http://www.amazon.com/Designing-Digital-Age-Human-Centered-Products/dp/0470229101) Kim Goodwin. 
-- [“Inside Goal-Directed Design: A Two-Part Conversation with Alan Cooper.”](http://www.cooper.com/journal/2014/04/inside-goal-directed-design-a-two-part-conversation-with-alan-cooper) Caroline Kraus. 
-- Book available for purchase: [*The Design of Everyday Things.*](http://www.amazon.com/The-Design-Everyday-Things-Expanded/dp/0465050654/) Don Norman. 
+- [*Designing for the Digital Age: How to Create Human-Centered Products and Services.*](http://www.amazon.com/Designing-Digital-Age-Human-Centered-Products/dp/0470229101) Kim Goodwin.
+- [“Inside Goal-Directed Design: A Two-Part Conversation with Alan Cooper.”](http://www.cooper.com/journal/2014/04/inside-goal-directed-design-a-two-part-conversation-with-alan-cooper) Caroline Kraus.
+- Book available for purchase: [*The Design of Everyday Things.*](http://www.amazon.com/The-Design-Everyday-Things-Expanded/dp/0465050654/) Don Norman.

--- a/_pages/decide/site-mapping.md
+++ b/_pages/decide/site-mapping.md
@@ -1,6 +1,7 @@
 ---
 title: Site mapping
 parent: Decide
+redirect_from: /site-mapping/
 ---
 
 ## What it is
@@ -21,7 +22,7 @@ To audit an existing website by assessing its structure and content. Site maps a
 
 2. Visually represent each page as a single thumbnail.
 
-3. Arrange the page thumbnails into a hierarchical diagram. Focus on the logical relationships between pages. If you are evaluating an existing website, focus more on these relationships than on the URL structure. If some pages function as sub-pages to another, the site map should reflect that. 
+3. Arrange the page thumbnails into a hierarchical diagram. Focus on the logical relationships between pages. If you are evaluating an existing website, focus more on these relationships than on the URL structure. If some pages function as sub-pages to another, the site map should reflect that.
 
 4. Use the diagram to guide choices about things like information architecture and URL structures.
 

--- a/_pages/decide/storyboarding.md
+++ b/_pages/decide/storyboarding.md
@@ -1,6 +1,7 @@
 ---
 title: Storyboarding
 parent: Decide
+redirect_from: /storyboarding/
 ---
 
 ## What it is
@@ -32,6 +33,6 @@ To visualize interactions and relationships that might exist between a user and 
 No PRA implications. No information is collected from members of the public.
 
 ## Additional resources:
-- Tool: [Communication Methods Supporting Design Processes.](http://www.servicedesigntools.org/tools/13) Service Design Tools. 
-- [“Storyboarding in the Software Design Process.”](http://uxmag.com/articles/storyboarding-in-the-software-design-process) Ambrose Little. 
-- [“The 8 Steps to Creating a Great Storyboard.”](http://www.fastcodesign.com/1672917/the-8-steps-to-creating-a-great-storyboard) Jake Knapp. 
+- Tool: [Communication Methods Supporting Design Processes.](http://www.servicedesigntools.org/tools/13) Service Design Tools.
+- [“Storyboarding in the Software Design Process.”](http://uxmag.com/articles/storyboarding-in-the-software-design-process) Ambrose Little.
+- [“The 8 Steps to Creating a Great Storyboard.”](http://www.fastcodesign.com/1672917/the-8-steps-to-creating-a-great-storyboard) Jake Knapp.

--- a/_pages/decide/style-tiles.md
+++ b/_pages/decide/style-tiles.md
@@ -1,6 +1,7 @@
 ---
 title: Style tiles
 parent: Decide
+redirect_from: /style-tiles/
 ---
 
 ## What it is
@@ -31,5 +32,5 @@ No PRA implications. No information is collected from members of the public.
 
 ## Additional resources
 
-- Tool: [Style Tiles: A Visual Web Design Process for Clients and the Responsive Web.](http://styletil.es/) Style Tiles. 
-- [“Style Tiles and How They Work.”](http://alistapart.com/article/style-tiles-and-how-they-work) Samantha Warren. 
+- Tool: [Style Tiles: A Visual Web Design Process for Clients and the Responsive Web.](http://styletil.es/) Style Tiles.
+- [“Style Tiles and How They Work.”](http://alistapart.com/article/style-tiles-and-how-they-work) Samantha Warren.

--- a/_pages/decide/task-flow-analysis.md
+++ b/_pages/decide/task-flow-analysis.md
@@ -1,6 +1,7 @@
 ---
 title: Task flow analysis
 parent: Decide
+redirect_from: /task-flow-analysis/
 ---
 
 ## What it is
@@ -33,5 +34,5 @@ No PRA implications. No information is collected from members of the public.
 
 ## Additional resources:
 
-- [“Task Analysis: The Key UX Design Step Everyone Skips.”](http://searchenginewatch.com/sew/how-to/2336547/task-analysis-the-key-ux-design-step-everyone-skips) Larry Maine. 
-- Tool: [Task Analysis.](http://www.usability.gov/how-to-and-tools/methods/task-analysis.html) Usability.gov. 
+- [“Task Analysis: The Key UX Design Step Everyone Skips.”](http://searchenginewatch.com/sew/how-to/2336547/task-analysis-the-key-ux-design-step-everyone-skips) Larry Maine.
+- Tool: [Task Analysis.](http://www.usability.gov/how-to-and-tools/methods/task-analysis.html) Usability.gov.

--- a/_pages/decide/user-scenarios.md
+++ b/_pages/decide/user-scenarios.md
@@ -1,6 +1,7 @@
 ---
 title: User scenarios
 parent: Decide
+redirect_from: /user-scenarios/
 ---
 
 ## What it is
@@ -36,5 +37,5 @@ No PRA implications. No information is collected from members of the public.
 
 ## Additional resources
 
-- Tool: [Scenarios.](http://www.usability.gov/how-to-and-tools/methods/scenarios.html) Usability.gov. 
+- Tool: [Scenarios.](http://www.usability.gov/how-to-and-tools/methods/scenarios.html) Usability.gov.
 - [“How User Scenarios Help To Improve Your UX.”](http://blog.usabilla.com/how-user-scenarios-help-to-improve-your-ux/) Sabina Idler.

--- a/_pages/discover/bodystorming.md
+++ b/_pages/discover/bodystorming.md
@@ -1,6 +1,7 @@
 ---
 title: Bodystorming
 parent: Discover
+redirect_from: /bodystorming/
 ---
 
 ## What it is

--- a/_pages/discover/cognitive-walkthrough.md
+++ b/_pages/discover/cognitive-walkthrough.md
@@ -1,6 +1,7 @@
 ---
 title: Cognitive walkthrough
 parent: Discover
+redirect_from: /cognitive-walkthrough/
 ---
 
 ## What it is

--- a/_pages/discover/contextual-inquiry.md
+++ b/_pages/discover/contextual-inquiry.md
@@ -1,6 +1,7 @@
 ---
 title: Contextual inquiry
 parent: Discover
+redirect_from: /contextual-inquiry/
 ---
 
 ## What it is

--- a/_pages/discover/design-studio.md
+++ b/_pages/discover/design-studio.md
@@ -1,6 +1,7 @@
 ---
 title: Design studio
 parent: Discover
+redirect_from: /design-studio/
 ---
 
 ## What it is

--- a/_pages/discover/feature-dot-voting.md
+++ b/_pages/discover/feature-dot-voting.md
@@ -1,6 +1,7 @@
 ---
 title: Feature dot voting
 parent: Discover
+redirect_from: /feature-dot-voting/
 ---
 
 ## What it is
@@ -34,4 +35,3 @@ To build group consensus quickly from the priorities of individual in the group.
 ## Applied in government research
 
 No PRA implications: feature dot voting falls under "direct observation", which is explicitly exempt from the PRA, 5 CFR 1320(h)3. See the methods for [Recruiting]({{ '/fundamentals/recruiting' | prepend: site.baseurl }}) and [Privacy]({{ '/fundamentals/privacy' | prepend: site.baseurl }}) for more tips on taking input from the public.
-

--- a/_pages/discover/heuristic-analysis.md
+++ b/_pages/discover/heuristic-analysis.md
@@ -1,6 +1,7 @@
 ---
 title: Heuristic analysis
 parent: Discover
+redirect_from: /heuristic-analysis/
 ---
 
 ## What it is

--- a/_pages/discover/kj-method.md
+++ b/_pages/discover/kj-method.md
@@ -1,6 +1,7 @@
 ---
 title: KJ method
 parent: Discover
+redirect_from: /kj-method/
 ---
 
 ## What it is
@@ -35,11 +36,11 @@ To reach a consensus on priorities of subjective, qualitative data with a group 
 
 ## Applied in government research
 
-At 18F, KJ participants are almost always federal employees. If there is any chance your KJ workshop could include participants who are not federal employees, consult OMB guidance on the Paperwork Reduction Act and the Privacy Act. Your agencies’ Office of General Counsel, and perhaps OIRA desk officers, also can ensure you are following the laws and regulations applicable to federal agencies. 
+At 18F, KJ participants are almost always federal employees. If there is any chance your KJ workshop could include participants who are not federal employees, consult OMB guidance on the Paperwork Reduction Act and the Privacy Act. Your agencies’ Office of General Counsel, and perhaps OIRA desk officers, also can ensure you are following the laws and regulations applicable to federal agencies.
 
 ## Additional resources
 
-[“The KJ-Technique: A Group Process for Establishing Priorities.”](http://www.uie.com/articles/kj_technique/) Jared M. Spool. 
+[“The KJ-Technique: A Group Process for Establishing Priorities.”](http://www.uie.com/articles/kj_technique/) Jared M. Spool.
 
 ## Example from 18F
 

--- a/_pages/discover/metrics-definition.md
+++ b/_pages/discover/metrics-definition.md
@@ -1,6 +1,7 @@
 ---
 title: Metrics definition
 parent: Discover
+redirect_from: /metrics-definition/
 ---
 
 ## What it is

--- a/_pages/discover/stakeholder-and-user-interviews.md
+++ b/_pages/discover/stakeholder-and-user-interviews.md
@@ -1,6 +1,7 @@
 ---
 title: Stakeholder and user interviews
 parent: Discover
+redirect_from: /stakeholder-and-user-interviews/
 ---
 
 ## What it is

--- a/_pages/fundamentals/incentives.md
+++ b/_pages/fundamentals/incentives.md
@@ -1,6 +1,7 @@
 ---
 title: Incentives
 parent: Fundamentals
+redirect_from: /incentives/
 ---
 
 ## What it is
@@ -16,6 +17,6 @@ Incentives often result in a more diverse, representative set of participants. W
 
 1. **Figure out what’s legal and appropriate.** Consult your agency’s Office of General Counsel on options for providing incentives or gifts to encourage participation in usability testing, consistent with your agency’s authorities. The options will depend upon your agency’s authorities and the specific facts.
 
-2. **Consider contracting for a recruiting service to help you get an effective research pool.** 
+2. **Consider contracting for a recruiting service to help you get an effective research pool.**
 
 3. **If incentives are determined to be permissible, clearly communicate when and how participants will receive incentives.** In the emails, postings or other materials you use to recruit your participants, describe the incentive and how participants will receive it (via mail, pick up at an office, etc.). This is particularly important for “remote” research.

--- a/_pages/fundamentals/privacy.md
+++ b/_pages/fundamentals/privacy.md
@@ -1,6 +1,7 @@
 ---
 title: Privacy
 parent: Fundamentals
+redirect_from: /privacy/
 ---
 
 ## What it is

--- a/_pages/fundamentals/recruiting.md
+++ b/_pages/fundamentals/recruiting.md
@@ -1,6 +1,7 @@
 ---
 title: Recruiting
 parent: Fundamentals
+redirect_from: /recruiting/
 ---
 
 ## What it is

--- a/_pages/make/design-pattern-library.md
+++ b/_pages/make/design-pattern-library.md
@@ -1,6 +1,7 @@
 ---
 title: Design pattern library
 parent: Make
+redirect_from: /design-pattern-library/
 ---
 
 ## What it is
@@ -34,5 +35,5 @@ No PRA implications. No information is collected from members of the public.
 ## Additional resources
 
 -  [“How and Why to Create a Pattern Library.”](https://boagworld.com/design/pattern-library/) Paul Boag.
-- [“Getting Started With Pattern Libraries.”](http://alistapart.com/blog/post/getting-started-with-pattern-libraries) Anna Debenham. 
-- [“How to Build the Perfect Pattern Library.”](http://www.slideshare.net/WolfBruening/how-to-build-the-perfect-pattern-libraryy) Wolf Brün. 
+- [“Getting Started With Pattern Libraries.”](http://alistapart.com/blog/post/getting-started-with-pattern-libraries) Anna Debenham.
+- [“How to Build the Perfect Pattern Library.”](http://www.slideshare.net/WolfBruening/how-to-build-the-perfect-pattern-libraryy) Wolf Brün.

--- a/_pages/make/protosketching.md
+++ b/_pages/make/protosketching.md
@@ -1,6 +1,7 @@
 ---
 title: Protosketching
 parent: Make
+redirect_from: /protosketching/
 ---
 
 ## What it is
@@ -33,4 +34,4 @@ No PRA implications. The PRA explicitly exempts direct observation and non-stand
 
 ## Additional resources
 
-[“Sketching with code: protosketching.”](https://18f.gsa.gov/2015/01/06/protosketch/) Alan Delevie. 
+[“Sketching with code: protosketching.”](https://18f.gsa.gov/2015/01/06/protosketch/) Alan Delevie.

--- a/_pages/make/prototyping.md
+++ b/_pages/make/prototyping.md
@@ -1,6 +1,7 @@
 ---
 title: Prototyping
 parent: Make
+redirect_from: /prototyping/
 ---
 
 ## What it is

--- a/_pages/make/wireframing.md
+++ b/_pages/make/wireframing.md
@@ -1,6 +1,7 @@
 ---
 title: Wireframing
 parent: Make
+redirect_from: /wireframing/
 ---
 
 ## What it is

--- a/_pages/validate/card-sorting.md
+++ b/_pages/validate/card-sorting.md
@@ -1,6 +1,7 @@
 ---
 title: Card sorting
 parent: Validate
+redirect_from: /card-sorting/
 ---
 
 ## What it is

--- a/_pages/validate/multivariate-testing.md
+++ b/_pages/validate/multivariate-testing.md
@@ -1,6 +1,7 @@
 ---
 title: Multivariate testing
 parent: Validate
+redirect_from: /multivariate-sorting/
 ---
 
 ## What it is
@@ -33,6 +34,5 @@ No PRA implications. No one asks the users questions, so the PRA does not apply.
 
 ## Additional resources
 
-- [Multivariate Testing in Action: Five Simple Steps to Increase Conversion Rates.](http://www.smashingmagazine.com/2010/11/multivariate-testing-in-action-five-simple-steps-to-increase-conversion-rates/) Paras Chopra. 
-- [Multivariate Testing 101: A Scientific Method of Optimizing Design.](http://www.smashingmagazine.com/2011/04/multivariate-testing-101-a-scientific-method-of-optimizing-design/) Paras Chopra. 
-
+- [Multivariate Testing in Action: Five Simple Steps to Increase Conversion Rates.](http://www.smashingmagazine.com/2010/11/multivariate-testing-in-action-five-simple-steps-to-increase-conversion-rates/) Paras Chopra.
+- [Multivariate Testing 101: A Scientific Method of Optimizing Design.](http://www.smashingmagazine.com/2011/04/multivariate-testing-101-a-scientific-method-of-optimizing-design/) Paras Chopra.

--- a/_pages/validate/usability-testing.md
+++ b/_pages/validate/usability-testing.md
@@ -1,6 +1,7 @@
 ---
 title: Usability testing
 parent: Validate
+redirect_from: /usability-testing/
 ---
 
 ## What it is

--- a/_pages/validate/visual-preference-testing.md
+++ b/_pages/validate/visual-preference-testing.md
@@ -1,6 +1,7 @@
 ---
 title: Visual preference testing
 parent: Validate
+redirect_from: /visual-preference-testing/
 ---
 
 ## What it is
@@ -33,5 +34,5 @@ No PRA implications. The PRA explicitly exempts direct observation and non-stand
 
 ## Additional resources
 
-- [Rapid Desirability Testing: A Case Study.](http://www.uxmatters.com/mt/archives/2010/02/rapid-desirability-testing-a-case-study.php) Michael Hawley. 
-- [Preference and Desirability Testing: Measuring Emotional Response to Guide Design.](http://www.slideshare.net/pwdoncaster/preference-and-desirability-testing-measuring-emotional-response-to-guide-design) Michael Hawley and Paul Doncaster. 
+- [Rapid Desirability Testing: A Case Study.](http://www.uxmatters.com/mt/archives/2010/02/rapid-desirability-testing-a-case-study.php) Michael Hawley.
+- [Preference and Desirability Testing: Measuring Emotional Response to Guide Design.](http://www.slideshare.net/pwdoncaster/preference-and-desirability-testing-measuring-emotional-response-to-guide-design) Michael Hawley and Paul Doncaster.


### PR DESCRIPTION
I've added the [jekyll-redirect-from](https://github.com/jekyll/jekyll-redirect-from) gem as a dependency to handle page redirection as requested in issue #112. 

With this gem, you can easily specify a page to redirect from in front matter. So if `/personas/` should redirect to `/decide/personas/`, I add `redirect_from: /personas/` to the front matter of `_pages/decide/personas.md`. The jekyll-redirect-from gem then creates a page at `/personas/` with a meta refresh tag pointing to the correct URL and triggering a client-side redirect.

I'll add that I also unintentionally eliminated trailing spaces from many of the markdown files thanks to my editor settings. Won't really affect anything, but thought I'd mention it since the diff looks like I changed a lot as a side effect.