### PR TITLE
Remove Ethnio codebase from live site.

### DIFF
--- a/_includes/ethnio.html
+++ b/_includes/ethnio.html
@@ -1,2 +1,0 @@
-<!-- Ethnio Activation Code -->
-<script type="text/javascript" language="javascript" src="//ethn.io/87050.js" async="true" charset="utf-8"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,7 +37,6 @@
       {% include footer.html %}
 
     </div> <!-- /.container -->
-    {% include ethnio.html %}
     {% guides_style_18f_include analytics.html %}
     {% guides_style_18f_include scripts.html %}
 


### PR DESCRIPTION
This pull request is to officially remove the Ethnio code from https://methods.18f.gov/. There was a [commit from the staging branch](bedab24b06a5f1b260afc60739633c9f6195792) that @jehlers and I were unsure whether or not they could be included on production yet, hence the rationale behind not merging `staging` > `master`. 

I also added one commit to remove it from the `default.html` layout file too.

Once this is merged in, please submit another pull request to merge `master` into `staging`.