### PR TITLE
Removing Ethn.io reference from default page template

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,7 +37,6 @@
       {% include footer.html %}
 
     </div> <!-- /.container -->
-    {% include ethnio.html %}
     {% guides_style_18f_include analytics.html %}
     {% guides_style_18f_include scripts.html %}
 


### PR DESCRIPTION
Removing a last reference to the Ethn.io snippet page in the includes folder. (We removed that snippet, so this reference is breaking the build.)