### PR TITLE
Moved 18F e.g. up under 18F e.g. heading

### DIFF
--- a/_pages/make/protosketching.md
+++ b/_pages/make/protosketching.md
@@ -29,7 +29,7 @@ To stimulate stakeholder imaginations and focus discussion on issues about data,
 5. As the meeting closes, emphasize that the protosketch isn’t necessarily the start of production-ready software, but a way to improve discussion about project requirements.
 
 ## Examples from 18F
-- ["How to prototosketch"](https://18f.gsa.gov/2015/03/13/how-to-protosketch/) Alan deLevie , Dr. Robert L. Read.
+- ["How to prototosketch."](https://18f.gsa.gov/2015/03/13/how-to-protosketch/) Alan deLevie , Dr. Robert L. Read.
 - [Example protosketch Github repository](https://github.com/18F/protosketch-demo)
 - [“Sketching with code: protosketching.”](https://18f.gsa.gov/2015/01/06/protosketch/) Alan Delevie.
 

--- a/_pages/make/protosketching.md
+++ b/_pages/make/protosketching.md
@@ -29,7 +29,7 @@ To stimulate stakeholder imaginations and focus discussion on issues about data,
 5. As the meeting closes, emphasize that the protosketch isn’t necessarily the start of production-ready software, but a way to improve discussion about project requirements.
 
 ## Examples from 18F
-- ["How to prototosketch" from 18F's blog](https://18f.gsa.gov/2015/03/13/how-to-protosketch/)
+- ["How to prototosketch"](https://18f.gsa.gov/2015/03/13/how-to-protosketch/) Alan deLevie , Dr. Robert L. Read.
 - [Example protosketch Github repository](https://github.com/18F/protosketch-demo)
 - [“Sketching with code: protosketching.”](https://18f.gsa.gov/2015/01/06/protosketch/) Alan Delevie.
 

--- a/_pages/make/protosketching.md
+++ b/_pages/make/protosketching.md
@@ -31,11 +31,11 @@ To stimulate stakeholder imaginations and focus discussion on issues about data,
 ## Examples from 18F
 - ["How to prototosketch" from 18F's blog](https://18f.gsa.gov/2015/03/13/how-to-protosketch/)
 - [Example protosketch Github repository](https://github.com/18F/protosketch-demo)
+- [“Sketching with code: protosketching.”](https://18f.gsa.gov/2015/01/06/protosketch/) Alan Delevie.
+
 
 ## Applied in government research
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3.
 
-## Additional resources
 
-[“Sketching with code: protosketching.”](https://18f.gsa.gov/2015/01/06/protosketch/) Alan Delevie.


### PR DESCRIPTION
Moved e.g. from under "additional resources heading to under "examples from 18F." Also deleted "additional resources" heading because it was no longer needed. 