### PR TITLE
Plain language edits

### DIFF
--- a/_pages/discover/feature-dot-voting.md
+++ b/_pages/discover/feature-dot-voting.md
@@ -6,11 +6,11 @@ redirect_from: /feature-dot-voting/
 
 ## What it is
 
-A simple voting exercise to identify a group’s collective priorities for potential features or user stories.
+A simple voting exercise to identify a group’s collective priorities for potential features.
 
 ## Reasons to use it
 
-To build group consensus quickly from the priorities of individual in the group.
+To build group consensus quickly from the priorities of individuals in the group.
 
 ## Time required
 
@@ -18,19 +18,19 @@ To build group consensus quickly from the priorities of individual in the group.
 
 ## How to do it
 
-1. Bring plenty of Post-It notes and “glue dots” to the meeting.
+1. Bring plenty of sticky notes and colored stickers to the meeting.
 
-2. Gather all people on the product team and anyone with a stake in the product’s features.
+2. Gather everyone on the product team and anyone with a stake in the product’s features.
 
-3. Quickly review the project’s goals and conclusions of any prior user research.
+3. Quickly review the project’s goals and the conclusions of any prior user research.
 
 4. Ask team members to take five minutes to write important features or user needs on sticky notes. (One feature per sticky note.)
 
 5. After five minutes, ask participants to put their stickies on a board. If there are many sticky notes, ask participants to put their features next to similar ones. Remove exact duplicates.
 
-6. Give participants three to five glue dots and instruct them to place their dots on features they feel are most important to meeting project goals and user needs.
+6. Give participants three to five colored stickers and instruct them to place their stickers on features they feel are most important to meeting the project's goals and user needs.
 
-7. Identify the features with the largest number of dots (votes).
+7. Identify the features with the largest number of stickers (votes).
 
 ## Applied in government research
 


### PR DESCRIPTION
Remove "user stories" because "potential features" seems to cover pretty much the same ground here. Let me know if that's not the case. 
Change Post-it and glue dots to more plain language. 
Other small changes. 
