### PR TITLE
Adds 18F button styles

### DIFF
--- a/_includes/method-print-header.html
+++ b/_includes/method-print-header.html
@@ -1,6 +1,6 @@
 <div class="card-header no-print">
   <nav>
-    <a href="{{sitebase.url}}/{{ page.category | downcase}}" class="usa-button">
+    <a href="{{sitebase.url}}/{{ page.category | downcase}}" class="usa-button-secondary">
       <img src="../images/cards.png" alt="" width="22">
       {% if page.layout == "category" %}
         See all cards
@@ -8,7 +8,7 @@
         See all {{ page.category | downcase}} cards
       {% endif %}
     </a>
-    <a href="javascript:window.print()" class="usa-button">
+    <a href="javascript:window.print()" class="usa-button-secondary">
       <img src="../images/printer.png" alt="" width="20">
       {% if page.layout == "category" %}
         Print all {{ page.category | downcase}} cards

--- a/_includes/method-print-header.html
+++ b/_includes/method-print-header.html
@@ -1,6 +1,6 @@
 <div class="card-header no-print">
   <nav>
-    <a href="{{sitebase.url}}/{{ page.category | downcase}}" class="usa-button-secondary">
+    <a href="{{sitebase.url}}/{{ page.category | downcase}}" class="usa-button usa-button-secondary">
       <img src="../images/cards.png" alt="" width="22">
       {% if page.layout == "category" %}
         See all cards
@@ -8,7 +8,7 @@
         See all {{ page.category | downcase}} cards
       {% endif %}
     </a>
-    <a href="javascript:window.print()" class="usa-button-secondary">
+    <a href="javascript:window.print()" class="usa-button usa-button-secondary">
       <img src="../images/printer.png" alt="" width="20">
       {% if page.layout == "category" %}
         Print all {{ page.category | downcase}} cards

--- a/_sass/uswds_overrides.scss
+++ b/_sass/uswds_overrides.scss
@@ -122,6 +122,25 @@ z-index: 10000;
     background-color: $color-blue-dark;
     color: $color-inverse;
   }
+}
 
+// 18F Button styles
+.usa-button,
+.usa-button:visited {
+  background-color: $color-medium;
+  font-family: $font-sans;
 
+  &:hover {
+    background-color: $color-medium-hover;
+  }
+}
+
+.usa-button-secondary,
+.usa-button-secondary:visited {
+  background-color: $color-bright;
+  color: $color-black;
+
+  &:hover {
+    background-color: $color-bright-hover;
+  }
 }

--- a/_sass/uswds_overrides.scss
+++ b/_sass/uswds_overrides.scss
@@ -126,21 +126,27 @@ z-index: 10000;
 
 // 18F Button styles
 .usa-button,
-.usa-button:visited {
+.usa-button:visited,
+button,
+[type='button'],
+[type='submit'],
+[type='reset'],
+[type='image'] {
   background-color: $color-medium;
   font-family: $font-sans;
+  width: auto;
 
   &:hover {
     background-color: $color-medium-hover;
   }
-}
 
-.usa-button-secondary,
-.usa-button-secondary:visited {
-  background-color: $color-bright;
-  color: $color-black;
+  &.usa-button-secondary,
+  &.usa-button-secondary:visited {
+    background-color: $color-bright;
+    color: $color-black;
 
-  &:hover {
-    background-color: $color-bright-hover;
+    &:hover {
+      background-color: $color-bright-hover;
+    }
   }
 }

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -17,7 +17,7 @@ $tiny-font-size: 1.2rem;
 $paragraph-line-height: 1.5;
 
 
-// Color
+// Colors
 $color-blue: #5CAED7;
 $color-green: #58B84F;
 $color-gold: #F3CD32;
@@ -26,6 +26,16 @@ $color-blue-dark: #1C304A; // 18F brand color $color-dark
 $color-gray-darkest: #222;
 $color-gray-dark: #333;
 $color-gray: #ddd;
+
+// 18F brand colors
+$color-light:        #b3efff; // $color-light / $color-secondary-light
+$color-bright:       #00cfff; // $color-bright / $color-secondary
+$color-medium:       #046b99; // $color-medium / $color-primary
+$color-dark:         #1C304A; // $color-dark / $color-primary-dark
+
+$color-bright-hover: #00A7CE;
+$color-medium-hover: #00547A;
+
 $color-gray-light: #f1f1f1; // 18F brand color $color-gray-lightest
 $color-gray-lightest: #fafafa; // 18F brand color $color-gray-hover
 $color-inverse: #fff; // 18F brand color


### PR DESCRIPTION
## Summary
Adds the button styles from the 18F site: 
Documentation: https://18f.gsa.gov/styleguide/components/#buttons
Code: https://github.com/18F/18f.gsa.gov/blob/master/_sass/_components/buttons.scss

- Uses `button-secondary` following style guidance due to the page
background colors
- Adds 18F color variables
- Adds primary and secondary button styles

## Remaining to-do's
@line47 when adding these styles, I hit a wall when I added the `.usa-button-secondary` class, which started interfering with the previous "button" styling. Here's a screenshot of the current state:
<img width="401" alt="screen shot 2017-04-26 at 2 17 34 pm" src="https://cloud.githubusercontent.com/assets/11636908/25457451/39b5d312-2a8b-11e7-9276-fede25634315.png">

Any pointers on what I'm doing wrong?