### PR TITLE
Convert prototyping method to markdown

### DIFF
--- a/_includes/method.html
+++ b/_includes/method.html
@@ -1,5 +1,5 @@
 {% assign this_method = include.method | default: page %}
-<span class="anchor" id="{{ method.title | slugify }}"></span>
+<span class="anchor" id="{{ this_method.title | slugify }}"></span>
 <article class="method" itemscope itemtype="http://schema.org/Article">
   <div class="method--panel method--panel--front">
     <h1 class="method--title" itemprop="headline"><a href="{{ site.baseurl }}{{ method.url }}">
@@ -11,7 +11,7 @@
       <h1>What</h1>
       <p>{{ this_method.what }}</p>
       <h1>Why</h1>
-      <p>{{ this_method.why }}</p>
+      <p>{{ this_method.why | liquify | markdownify }}</p>
     <footer>
       <section class="method-section method--section--category">
         <h1>Phase</h1>

--- a/_methods/prototyping.md
+++ b/_methods/prototyping.md
@@ -4,17 +4,16 @@ title: Prototyping
 description: A rudimentary version, either static or functional, of something that exhibits realistic form and function.
 category: Make
 what: A rudimentary version, either static or functional, of something that exhibits realistic form and function.
-why:
-  To enable direct examination of a design concept’s viability with a number of other methods such as [usability testing]('/usability-testing') or a [cognitive walkthrough]('/cognitive-walkthrough'). Static prototypes (often paper) are helpful for gaining feedback on users’ intentions and various design elements. Functional prototypes (often coded) are helpful for observing how users interact with the product.
+why: |
+  To enable direct examination of a design concept’s viability with a number of other methods such as [usability testing](/usability-testing/#usability-testing) or a [cognitive walkthrough](/cognitive-walkthrough/#cognitive-walkthrough). Static prototypes (often paper) are helpful for gaining feedback on users’ intentions and various design elements. Functional prototypes (often coded) are helpful for observing how users interact with the product.
 timeRequired: 4 hours
-how:
-  <ol>
-    <li>Create a rudimentary version of your product. It can be static or functional. Think in the same way you would about a <a href="/wireframing">wireframe</a>&#58; demonstrate structure and relationships among different elements, but don&rsquo;t worry about stylized elements.</li>
-    <li>Give the prototype to the user and observe their interactions without instruction.</li>
-    <li>After this observation, ask them to perform a specific task.</li>
-    <li>Ask clarifying questions about why they do what they do. Let the user&rsquo;s behavior guide the questions you ask. It can be helpful to have them narrate their thought process as they go along.</li>
-    <li>Iterate! Prototypes should be quick and painless to create, and even more quick and painless to discard.</li>
-  </ol>
-governmentConsiderations:
-  <p>No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for <a href="/recruiting">Recruiting</a> and <a href="/privacy">Privacy</a> for more tips on taking input from the public.</p>
+how: |
+  1. Create a rudimentary version of your product. It can be static or functional. Think in the same way you would about a [wireframe](/wireframing/#wireframing): demonstrate structure and relationships among different elements, but don't worry about stylized elements.
+  2. Give the prototype to the user and observe their interactions without instruction.
+  3. After this observation, ask them to perform a specific task.
+  4. Ask clarifying questions about why they do what they do. Let the user's behavior guide the questions you ask. It can be helpful to have them narrate their thought process as they go along.
+  5. Iterate! Prototypes should be quick and painless to create, and even more quick and painless to discard.
+
+governmentConsiderations: |
+  No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](/recruiting/#recruiting) and [Privacy](/privacy/#privacy) for more tips on taking input from the public.
 ---


### PR DESCRIPTION
- Updated the method file to allow for the `why` content to be Markdown
- Updated the anchor tag variable so it would populate with the method
title