### PR TITLE
Converting validate methods to Markdown

### DIFF
--- a/_includes/method.html
+++ b/_includes/method.html
@@ -19,7 +19,7 @@
       </section>
       <section class="method-section method--section--time-required">
         <h1>Time required</h1>
-        <p>{{ this_method.timeRequired }}</p>
+        <p>{{ this_method.timeRequired | liquify | markdownify }}</p>
       </section>
     </footer>
   </div>

--- a/_methods/multivariate-testing.md
+++ b/_methods/multivariate-testing.md
@@ -6,20 +6,18 @@ category: Validate
 what: A test of variations to multiple sections or features of a page to see which combination of variants has the greatest effect. Different from an A/B test, which tests variation to just one section or feature.
 why: To incorporate different contexts, channels, or user types into addressing a user need. Situating a call to action, content section, or feature set differently can help you build a more effective whole solution from a set of partial solutions.
 timeRequired: 2–5 days of effort, 1–4 weeks elapsed through the testing period
-how:
-  <ol>
-    <li>Identify the call to action, content section, or feature that needs to be improved to increase conversion rates or user engagement.</li>
-    <li>Develop a list of possible issues that may be hurting conversion rates or engagement. Specify in advance what you are optimizing for (possibly through <a href="/metrics-definition">metrics definition</a>.</li>
-    <li>Design several solutions that aim to address the issues listed. Each solution should attempt to address every issue by using a unique combination of variants so each solution can be compared fairly.</li>
-    <li>Use a web analytics tool that supports multivariate testing, such as Google Website Optimizer or Visual Website Optimizer, to set up the testing environment. Conduct the test for long enough to produce statistically significant results.</li>
-    <li>Analyze the testing results to determine which solution produced the best conversion or engagement rates. Review the other solutions, as well, to see if there is information worth examining in with future studies.</li>  
-  </ol>
-nonPrintableContent:
-  <h1>Additional resources</h1>
-  <ul>
-    <li><a href="http://www.smashingmagazine.com/2010/11/multivariate-testing-in-action-five-simple-steps-to-increase-conversion-rates/">Multivariate Testing in Action&colon; Five Simple Steps to Increase Conversion Rates. Paras Chopra.</a></li>
-    <li><a href="http://www.smashingmagazine.com/2011/04/multivariate-testing-101-a-scientific-method-of-optimizing-design/">Multivariate Testing 101&colon; A Scientific Method of Optimizing Design. Paras Chopra.</a></li>
-  </ul>
-governmentConsiderations:
-  <p>No PRA implications. No one asks the users questions, so the PRA does not apply. See the methods for <a href="/recruiting">Recruiting</a> and <a href="/privacy">Privacy</a> for more tips on taking input from the public.</p>
+how: |
+  - Identify the call to action, content section, or feature that needs to be improved to increase conversion rates or user engagement.
+  - Develop a list of possible issues that may be hurting conversion rates or engagement. Specify in advance what you are optimizing for (possibly through [metrics definition](/metrics-definition/#metrics-definition).
+  - Design several solutions that aim to address the issues listed. Each solution should attempt to address every issue by using a unique combination of variants so each solution can be compared fairly.
+  - Use a web analytics tool that supports multivariate testing, such as Google Website Optimizer or Visual Website Optimizer, to set up the testing environment. Conduct the test for long enough to produce statistically significant results.
+  - Analyze the testing results to determine which solution produced the best conversion or engagement rates. Review the other solutions, as well, to see if there is information worth examining in with future studies.  
+nonPrintableContent: |
+  # Additional resources
+
+  - [Multivariate Testing in Action&colon; Five Simple Steps to Increase Conversion Rates. Paras Chopra.](http://www.smashingmagazine.com/2010/11/multivariate-testing-in-action-five-simple-steps-to-increase-conversion-rates/)
+  - [Multivariate Testing 101: A Scientific Method of Optimizing Design. Paras Chopra.](http://www.smashingmagazine.com/2011/04/multivariate-testing-101-a-scientific-method-of-optimizing-design/)
+
+governmentConsiderations: |
+  No PRA implications. No one asks the users questions, so the PRA does not apply. See the methods for [Recruiting](/recruiting/#recruiting) and [Privacy](/privacy/#privacy) for more tips on taking input from the public.
 ---

--- a/_methods/usability-testing.md
+++ b/_methods/usability-testing.md
@@ -4,30 +4,26 @@ title: Usability testing
 description: Observation of people attempting to use a product.
 category: Validate
 what: Observation of people attempting to use a product.
-why: To learn a given design&rsquo;s challenges, opportunities, and successes.
+why: To learn a given design's challenges, opportunities, and successes.
 timeRequired: 30 minutes to 1 hour per person
-how:
-  <ol>
-    <li><a href="/prototyping">Create a prototype</a> that sufficiently conveys the team&rsquo;s hypothesis based on research. In the absence of a prototype, consider testing a <a href="/comparative-analysis">competitor&rsquo;s product</a>.</li>
-    <li>
-      Stage a scenario in which someone who would actually use your product tries to complete a task. Record their attempt. Optionally&#58;
-      <ul>
-        <li>Ask users to think out loud as they try.</li>
-        <li><a href="/incentives">Compensate the participant</a> for their time.</li>    
-      </ul>
-    </li>
-    <li>Avoid asking participants to perform tasks far outside their normal context. This will lead them to reflect on the design rather than their ability to accomplish their goals. (For example, to test a new layout for a &ldquo;user account&rdquo; section on a voter registration website, recruit only people who already register to vote online.)</li>
-    <li>Analyze the user&rsquo;s attempt to complete the task, looking especially for areas where they struggled or questions they asked to inform design changes.</li>
-  </ol>
-nonPrintableContent:
-  <h1>Examples from 18F</h1>
-  <ul>
-    <li><a href="https://github.com/18F/doi-extractives-data/tree/research/research">Usability testing plans from 18F&rsquo;s Extractive Industries Transparency Initative project with Department of the Interior</a></li>
-    <li><a href="https://18f.gsa.gov/2016/02/09/tips-for-capturing-the-best-data-from-user-interviews/">Tips for capturing the best data from user interviews</a> Ryan Sibley.</li>
-  </ul>
-  <h1>Additional resources</h1>
-  <p><a href="http://www.usabilitybok.org/summative-usability-testing">An explanation of summative usability testing and how to conduct evaluations using this method.</a> The Usability Body of Knowledge, a product of the User Experience Professionals&rsquo; Association.</p>
+how: |
+  1. [Create a prototype](/prototyping/#prototyping) that sufficiently conveys the team's hypothesis based on research. In the absence of a prototype, consider testing a [competitor's product](/comparative-analysis/#comparative-analysis).
+  2. Stage a scenario in which someone who would actually use your product tries to complete a task. Record their attempt. Optionally:
+      - Ask users to think out loud as they try.
+      - [Compensate the participant](/incentives/#incentives) for their time.
+  3. Avoid asking participants to perform tasks far outside their normal context. This will lead them to reflect on the design rather than their ability to accomplish their goals. (For example, to test a new layout for a "user account" section on a voter registration website, recruit only people who already register to vote online.)
+  4. Analyze the user's attempt to complete the task, looking especially for areas where they struggled or questions they asked to inform design changes.
 
-governmentConsiderations:
-  <p>No PRA implications. First, any given usability test should involve nine or fewer users. Additionally, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. It also specifically excludes tests of knowledge or aptitude, 5 CFR 1320.3(h)7, which is essentially what a usability test tests. See the methods for <a href="/recruiting">Recruiting</a> and <a href="/privacy">Privacy</a> for more tips on taking input from the public.</p>
+nonPrintableContent: |
+  # Examples from 18F
+
+  - [Usability testing plans from 18F's Extractive Industries Transparency Initative project with Department of the Interior](https://github.com/18F/doi-extractives-data/tree/research/research)
+  - [Tips for capturing the best data from user interviews](https://18f.gsa.gov/2016/02/09/tips-for-capturing-the-best-data-from-user-interviews/) Ryan Sibley.
+
+  # Additional resources
+
+  [An explanation of summative usability testing and how to conduct evaluations using this method.](http://www.usabilitybok.org/summative-usability-testing) The Usability Body of Knowledge, a product of the User Experience Professionals' Association.
+
+governmentConsiderations: |
+  No PRA implications. First, any given usability test should involve nine or fewer users. Additionally, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. It also specifically excludes tests of knowledge or aptitude, 5 CFR 1320.3(h)7, which is essentially what a usability test tests. See the methods for [Recruiting](/recruiting/#recruiting) and [Privacy](/privacy/#privacy) for more tips on taking input from the public.
 ---

--- a/_methods/visual-preference-testing.md
+++ b/_methods/visual-preference-testing.md
@@ -5,24 +5,21 @@ description: A method that allows potential users to review and provide feedback
 category: Validate
 what: A method that allows potential users to review and provide feedback on a solution’s visual direction.
 why: To align the established branding guidelines and attributes of a solution with the way end users view the overall brand and emotional feel.
-timeRequired: 4-12 hours for [style tiles]('/decide/style-tiles/'). 30 minutes per participant to get feedback.
-how:
-  <ol>
-    <li>Create iterations of a style tile that represent directions a final visual design may follow. If branding guidelines or attributes don’t exist, establish them with stakeholders beforehand.</li>
-    <li>Interview participants about their reaction to the style tiles.</li>
-      <ul>Ask questions as objectively as possible.<ul>
-      <ul>Align questions with the branding guidelines and attributes your project must incorporate.<ul>
-      <ul>As far as possible, allow participants to provide their feedback unmoderated or at the end of your research.<ul>
-    <li>As far as possible, allow participants to provide their feedback unmoderated or at the end of a research study.</li>
-    <li>Compare the results of your research with the agency's published branding guidelines and attributes.</li>
-    <li>Publish the results to the complete product team and decide which direction will guide future design efforts.</li>
-  </ul>
-nonPrintableContent:
-  <h1>Additional resources</h1>
-  <ul>
-    <li><a href="http://www.uxmatters.com/mt/archives/2010/02/rapid-desirability-testing-a-case-study.php">Rapid Desirability Testing&colon; A Case Study.</a> Michael Hawley.</li>
-    <li><a href="http://www.slideshare.net/pwdoncaster/preference-and-desirability-testing-measuring-emotional-response-to-guide-design">Preference and Desirability Testing&colon; Measuring Emotional Response to Guide Design.</a> Michael Hawley and Paul Doncaster.</li>
-  </ul>
-governmentConsiderations:
-  <p>No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for <a href="/recruiting">Recruiting</a> and <a href="/privacy">Privacy</a> for more tips on taking input from the public.</p>
+timeRequired: |
+  4-12 hours for [style tiles](/style-tiles/#style-tiles). 30 minutes per participant to get feedback.
+how: |
+  1. Create iterations of a style tile that represent directions a final visual design may follow. If branding guidelines or attributes don’t exist, establish them with stakeholders beforehand.
+  2. Interview participants about their reaction to the style tiles.
+    - Ask questions as objectively as possible.
+    - Align questions with the branding guidelines and attributes your project must incorporate.
+    - As far as possible, allow participants to provide their feedback unmoderated or at the end of your research.
+  3. Compare the results of your research with the agency's published branding guidelines and attributes.
+  4. Publish the results to the complete product team and decide which direction will guide future design efforts.
+
+nonPrintableContent: |
+  # Additional resources
+    - [Rapid Desirability Testing&colon; A Case Study.](http://www.uxmatters.com/mt/archives/2010/02/rapid-desirability-testing-a-case-study.php) Michael Hawley.
+    - [Preference and Desirability Testing&colon; Measuring Emotional Response to Guide Design.](http://www.slideshare.net/pwdoncaster/preference-and-desirability-testing-measuring-emotional-response-to-guide-design) Michael Hawley and Paul Doncaster.
+governmentConsiderations: |
+  No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](/recruiting/#recruiting) and [Privacy](/privacy/#privacy) for more tips on taking input from the public.
 ---


### PR DESCRIPTION
Converted Multivariate testing, Usability testing and Visual preference
testing methods to use Markdown

Added the ability to use markdown in `timeRequired` as the Visual
preference testing method needs that support.