### PR TITLE
Fix navigation button color on expanded hover

### DIFF
--- a/_sass/uswds_overrides.scss
+++ b/_sass/uswds_overrides.scss
@@ -23,7 +23,7 @@
 .usa-skipnav:focus {
 z-index: 10000;
 }
-.usa-nav-primary button:hover,
+.usa-nav-primary button[aria-expanded=false]:hover,
 .usa-nav-secondary-links a:hover  {
   background-color: $color-gray-lightest;
   color: $color-black;


### PR DESCRIPTION
The text of the expanded nav button is black when you hover over it, making it hard to read. This ensures it stays white.

Before:
<img width="291" alt="screen shot 2017-05-23 at 11 57 00 am" src="https://cloud.githubusercontent.com/assets/5249443/26371256/0e51e9f2-3faf-11e7-9d49-056de8db3564.png">


After:
<img width="294" alt="screen shot 2017-05-23 at 11 58 01 am" src="https://cloud.githubusercontent.com/assets/5249443/26371266/170162a8-3faf-11e7-90ab-9d744a173643.png">
