### PR TITLE
permalink was missing

### DIFF
--- a/_methods/design-studio.md
+++ b/_methods/design-studio.md
@@ -1,6 +1,7 @@
 ---
 layout: card
 title: Design studio
+permalink: /discover/design-studio/
 description: An illustration-based way to facilitate communication (and brainstorming) between a project team and stakeholders.
 category: Discover
 what: An illustration-based way to facilitate communication (and brainstorming) between a project team and stakeholders.


### PR DESCRIPTION
Added permalink to design studio method

Preview: https://federalist-proxy.app.cloud.gov/preview/18f/methods/missing-permalink/

Permalink was missing the category in the URL: `/design-studio/`

Permalink is now:  `/discover/design-studio/`