### PR TITLE
Changed Heuristic Analysis to Heuristic Evaluation

### DIFF
--- a/_methods/heuristic-evaluation.md
+++ b/_methods/heuristic-evaluation.md
@@ -1,7 +1,7 @@
 ---
 layout: card
-title: Heuristic analysis
-permalink: /discover/heuristic-analysis/
+title: Heuristic evaluation
+permalink: /discover/heuristic-evaluation/
 description: A quick way to find common, large usability problems on a website.
 category: Discover
 what: A quick way to find common, large usability problems on a website.

--- a/_pages/discover.md
+++ b/_pages/discover.md
@@ -22,5 +22,5 @@ Learn as much as you can about the project and people involved.
 - [Bodystorming](bodystorming/)
 - [Cognitive walkthrough](cognitive-walkthrough/)
 - [Contextual inquiry](contextual-inquiry/)
-- [Heuristic analysis](heuristic-analysis/)
+- [Heuristic analysis](heuristic-evaluation/)
 - [Stakeholder and user interviews](stakeholder-and-user-interviews/)


### PR DESCRIPTION
Apologies if this PR is pointed at the wrong branch, but I didn't see a branch named `18f-pages-staging` to open against like the contributing docs recommended.

Changes: 
- File rename of heuristic-analysis to heuristic-evaluation
- Changed text "analysis" => "evaluation" for the method

Notes:
The reason for this change is to make the language clearer and more consistent around this method. If you search online for "Heuristic Analysis", one of the first results is [this Wikipedia article](https://en.wikipedia.org/wiki/Heuristic_analysis) that is about detecting viruses. Using the phrase "Evaluation" instead of "Analysis" should differentiate the two and possibly even help searchers find this page online. As for consistency, the link provided in the method itself points to an article that uses the phrase "Evaluation" instead of "Analysis". 

