### PR TITLE
Fix flash of pull-down menus on page load

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -40,7 +40,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="side-nav-1">
               <span>Discover</span>
             </button>
-            <ul id="side-nav-1" class="usa-nav-submenu">
+            <ul id="side-nav-1" class="usa-nav-submenu" aria-hidden="true">
               {% assign discovermethods = discover_methods | sort:"title"  %}
               {% for method in discovermethods %}
                 <li><a href="{{site.baseurl}}/#{{ method.title | slugify }}">{{ method.title }}</a></li>
@@ -52,7 +52,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-2">
               <span>Decide</span>
             </button>
-            <ul id="sidenav-2" class="usa-nav-submenu">
+            <ul id="sidenav-2" class="usa-nav-submenu" aria-hidden="true">
               {% assign decidemethods = decide_methods | sort:"title"  %}
               {% for method in decidemethods %}
                 <li><a href="{{site.baseurl}}/#{{ method.title | slugify }}">{{ method.title }}</a></li>
@@ -64,7 +64,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-3">
               <span>Make</span>
             </button>
-            <ul id="sidenav-3" class="usa-nav-submenu">
+            <ul id="sidenav-3" class="usa-nav-submenu" aria-hidden="true">
               {% assign makemethods = make_methods | sort:"title"  %}
               {% for method in makemethods %}
                 <li><a href="{{site.baseurl}}/#{{ method.title | slugify }}">{{ method.title }}</a></li>
@@ -76,7 +76,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-4">
               <span>Validate</span>
             </button>
-            <ul id="sidenav-4" class="usa-nav-submenu">
+            <ul id="sidenav-4" class="usa-nav-submenu" aria-hidden="true">
               {% assign validatemethods = validate_methods | sort:"title"  %}
               {% for method in validatemethods %}
                 <li><a href="{{site.baseurl}}/#{{ method.title | slugify }}">{{ method.title }}</a></li>
@@ -88,7 +88,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             <button class="usa-accordion-button usa-nav-link" aria-expanded="false" aria-controls="sidenav-5">
               <span>Fundamentals</span>
             </button>
-            <ul id="sidenav-5" class="usa-nav-submenu">
+            <ul id="sidenav-5" class="usa-nav-submenu" aria-hidden="true">
               {% assign fundamentalsmethods = fundamentals_methods | sort:"title"  %}
               {% for method in fundamentalsmethods %}
                 <li><a href="{{site.baseurl}}/#{{ method.title | slugify }}">{{ method.title }}</a></li>


### PR DESCRIPTION
**Changes**
- Adds `aria-hidden=true` to pull-down menus

**Notes** 
This bug appears to exist in the [web standards pull down menus as well](https://standards.usa.gov/components/headers/basic/). Since JavaScript is adding the aria-hidden attribute and CSS is relying on it to hide the menus, we end up with a race during page load to execute the JS fast enough to hide the menus before CSS can render. This prevents that from happening by adding the default attributes in markup. 

**Screenshots**
![2017-12-02 21 04 39](https://user-images.githubusercontent.com/347079/33521611-51d20656-d7a5-11e7-8848-1e962bdc18a0.gif)

Closes https://github.com/18F/methods/issues/301