### PR TITLE
Change "government considerations"

### DIFF
--- a/_methods/Design-hypotheses.md
+++ b/_methods/Design-hypotheses.md
@@ -43,7 +43,7 @@ timeRequired: 1-2 hours
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/affinity-diagramming.md
+++ b/_methods/affinity-diagramming.md
@@ -28,6 +28,6 @@ timeRequired: 1 hour
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
-## Applied in government research
+## Considerations for use in government
 No PRA implications. This method may use data gathered from members of the public, but does not require their involvement.
 </section>

--- a/_methods/affinity-diagramming.md
+++ b/_methods/affinity-diagramming.md
@@ -21,13 +21,16 @@ timeRequired: 1 hour
 
 
 <section class="method--section method--section--additional-resources" markdown="1">
-## Additional resources
+
+## Additional resources  
 
 - [An explanation of what affinity diagramming is and how to do it.](http://www.usabilitybok.org/affinity-diagram) The Usability Body of Knowledge, a product of the User Experience Professionals' Association.
 - [An explanation of affinity diagramming.](http://infodesign.com.au/usabilityresources/affinitydiagramming/) Information and Design.
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
-## Considerations for use in government
+
+## Considerations for use in government  
+
 No PRA implications. This method may use data gathered from members of the public, but does not require their involvement.
 </section>

--- a/_methods/card-sorting.md
+++ b/_methods/card-sorting.md
@@ -34,6 +34,6 @@ There are two types of card sorting: open and closed. Most card sorts are perfor
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
-## Applied in government research
+## Considerations for use in government
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. It also explicitly excludes tests of knowledge or aptitude, 5 CFR 1320.3(h)7, which is essentially what a card sort tests (though in our case, a poor result is our fault).
 </section>

--- a/_methods/card-sorting.md
+++ b/_methods/card-sorting.md
@@ -33,7 +33,9 @@ There are two types of card sorting: open and closed. Most card sorts are perfor
 - [Research plan including card sorting from 18F's C2 project](https://github.com/18F/C2/wiki/Sprint-5:-Interaction-model-June-2016)
 </section>
 
-<section class="method--section method--section--government-considerations" markdown="1" >
-## Considerations for use in government
+<section class="method--section method--section--government-considerations" markdown="1" > 
+
+## Considerations for use in government  
+
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. It also explicitly excludes tests of knowledge or aptitude, 5 CFR 1320.3(h)7, which is essentially what a card sort tests (though in our case, a poor result is our fault).
 </section>

--- a/_methods/cognitive-walkthrough.md
+++ b/_methods/cognitive-walkthrough.md
@@ -21,14 +21,17 @@ timeRequired: 30 minutes to one hour per person
   1. Pay attention to expected outcomes and how quickly/easily participants are able to pick up a task.
 1. Analyze the walkthrough results to highlight where the user struggled and what needs improvement.
 
-<section class="method--section method--section--additional-resources" markdown="1">
-## Additional resources
+<section class="method--section method--section--additional-resources" markdown="1">  
+
+## Additional resources  
 
 - [An explanation of cognitive walkthroughs and how to conduct one.](http://www.usabilitybok.org/cognitive-walkthrough) The Usability Body of Knowledge, a product of the User Experience Professionals' Association.
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
-## Considerations for use in government
+
+## Considerations for use in government  
+
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey) that a cognitive walkthrough entails, 5 CFR 1320.3(h)3.
 
 If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.

--- a/_methods/cognitive-walkthrough.md
+++ b/_methods/cognitive-walkthrough.md
@@ -28,7 +28,7 @@ timeRequired: 30 minutes to one hour per person
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
-## Applied in government research
+## Considerations for use in government
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey) that a cognitive walkthrough entails, 5 CFR 1320.3(h)3.
 
 If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.

--- a/_methods/comparative-analysis.md
+++ b/_methods/comparative-analysis.md
@@ -27,6 +27,6 @@ timeRequired: 1–2 hours to analyze and write an evaluation about each competit
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
-## Applied in government research
+## Considerations for use in government
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/comparative-analysis.md
+++ b/_methods/comparative-analysis.md
@@ -28,5 +28,6 @@ timeRequired: 1–2 hours to analyze and write an evaluation about each competit
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 ## Considerations for use in government
+
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/comparative-analysis.md
+++ b/_methods/comparative-analysis.md
@@ -27,7 +27,8 @@ timeRequired: 1–2 hours to analyze and write an evaluation about each competit
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
-## Considerations for use in government
+
+## Considerations for use in government  
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/content-audit.md
+++ b/_methods/content-audit.md
@@ -47,6 +47,6 @@ timeRequired: 3-8 hours
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
-## Applied in government research
+## Considerations for use in government
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/content-audit.md
+++ b/_methods/content-audit.md
@@ -39,6 +39,7 @@ timeRequired: 3-8 hours
 </section>
 
 <section class="method--section method--section--additional-resources" markdown="1">
+
 ## Additional resources  
 
 - <a href="http://uxmastery.com/how-to-conduct-a-content-audit/">"How to Conduct a Content Audit."</a> UX Mastery.
@@ -47,6 +48,8 @@ timeRequired: 3-8 hours
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
+
 ## Considerations for use in government  
+
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/content-audit.md
+++ b/_methods/content-audit.md
@@ -39,7 +39,7 @@ timeRequired: 3-8 hours
 </section>
 
 <section class="method--section method--section--additional-resources" markdown="1">
-## Additional resources
+## Additional resources  
 
 - <a href="http://uxmastery.com/how-to-conduct-a-content-audit/">"How to Conduct a Content Audit."</a> UX Mastery.
 - <a href="http://blog.braintraffic.com/2012/04/auditing-big-sites-doesn%E2%80%99t-have-to-be-taxing/">"Auditing Big Sites Doesn't Have to Be Taxing."</a> Christine Anameier.
@@ -47,6 +47,6 @@ timeRequired: 3-8 hours
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
-## Considerations for use in government
+## Considerations for use in government  
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/contextual-inquiry.md
+++ b/_methods/contextual-inquiry.md
@@ -38,7 +38,7 @@ A pair of 18F team members visited two Department of Labor/Wage Hour Division in
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research  
+## Considerations for use in government  
 
 No PRA implications, if done properly. Contextual interviews should be non-standardized, conversational, and based on observation. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](/fundamentals/recruiting/) and [Privacy](/fundamentals/privacy/) for more tips on taking input from the public.
 

--- a/_methods/contextual-inquiry.md
+++ b/_methods/contextual-inquiry.md
@@ -28,14 +28,16 @@ A pair of 18F team members visited two Department of Labor/Wage Hour Division in
 </section>
 
 <section class="method--section method--section--additional-resources" markdown="1" >
-## Additional resources
+
+## Additional resources  
 
 - [Observational research: 5 Tips for Improving Your Approach](https://hodigital.blog.gov.uk/2019/01/18/observational-research-5-tips-for-improving-your-approach%e2%80%af%e2%80%af/)
 
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
-## Applied in government research
+
+## Applied in government research  
 
 No PRA implications, if done properly. Contextual interviews should be non-standardized, conversational, and based on observation. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](/fundamentals/recruiting/) and [Privacy](/fundamentals/privacy/) for more tips on taking input from the public.
 

--- a/_methods/contextual-inquiry.md
+++ b/_methods/contextual-inquiry.md
@@ -21,7 +21,8 @@ governmentConsiderations:
 1. Immediately after, write up your notes.  
 
 <section class="method--section method--section--18f-example" markdown="1" >
-## Example from 18F
+
+## Example from 18F  
 
 A pair of 18F team members visited two Department of Labor/Wage Hour Division investigators as they interviewed home health care workers who were subject to unpaid overtime and other infractions. Since it was a sensitive subject, the 18F team did not question the health care workers directly, but instead asked the investigators clarifying questions in private. 18F staff also made sure that photos did not include faces.
 

--- a/_methods/design-pattern-library.md
+++ b/_methods/design-pattern-library.md
@@ -21,7 +21,7 @@ timeRequired: 1–2 hours per pattern; ongoing maintenance.
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/design-principles.md
+++ b/_methods/design-principles.md
@@ -38,7 +38,7 @@ timeRequired: 1 week, plus occasional refresher meetings
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA implications. Generally, no information is collected from members of the public. Even when stakeholders are members of the public, the PRA explicitly exempts direct observation and non-standardized conversation (e.g., not a survey), 5 CFR 1320.3(h)3. See the methods for [Recruiting](/fundamentals/recruiting/) and [Privacy](/fundamentals/privacy/) for more tips on taking input from the public.
 </section>

--- a/_methods/design-studio.md
+++ b/_methods/design-studio.md
@@ -31,7 +31,7 @@ timeRequired: 3–4 hours
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA implications. If conducted with nine or fewer members of the public, the PRA does not apply, 5 CFR 1320.5(c)4. If participants are employees, the PRA does not apply.
 </section>

--- a/_methods/dot-voting.md
+++ b/_methods/dot-voting.md
@@ -25,7 +25,7 @@ timeRequired: 15 minutes
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA implications: dot voting falls under "direct observation", which is explicitly exempt from the PRA, 5 CFR 1320(h)3. See the methods for [Recruiting](/fundamentals/recruiting/) and [Privacy](/fundamentals/privacy/) for more tips on taking input from the public.
 </section>

--- a/_methods/heuristic-evaluation.md
+++ b/_methods/heuristic-evaluation.md
@@ -33,7 +33,7 @@ timeRequired: 1–2 hours
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA Implications, as heuristic evaluations usually include a small number of evaluators. If conducted with nine or fewer members of the public, the PRA does not apply, 5 CFR 1320.5(c)4. If participants are employees, the PRA does not apply. See the methods for [Recruiting](/fundamentals/recruiting/) and [Privacy](/fundamentals/privacy/) for more tips on taking input from the public.
 </section>

--- a/_methods/hopes-and-fears.md
+++ b/_methods/hopes-and-fears.md
@@ -42,7 +42,7 @@ This format can be adapted to include other categories. For example, asking part
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/incentives.md
+++ b/_methods/incentives.md
@@ -20,7 +20,7 @@ timeRequired: N/A
 
 ## Considerations for use in government  
 
-- No PRA implications. Even when users are present, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3.
-- If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.
+No PRA implications. Even when users are present, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3.  
+If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.
 
 </section>

--- a/_methods/incentives.md
+++ b/_methods/incentives.md
@@ -21,6 +21,7 @@ timeRequired: N/A
 ## Considerations for use in government  
 
 No PRA implications. Even when users are present, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3.  
+  
 If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.
 
 </section>

--- a/_methods/incentives.md
+++ b/_methods/incentives.md
@@ -18,7 +18,7 @@ timeRequired: N/A
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 - No PRA implications. Even when users are present, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3.
 - If you are not working with government employees, you will need to observe standard precautions for archiving personally identifiable information.

--- a/_methods/journey-mapping.md
+++ b/_methods/journey-mapping.md
@@ -34,7 +34,7 @@ timeRequired: 4–12 hours
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](/fundamentals/recruiting/#recruiting) and [Privacy](/fundamentals/privacy/#privacy) for more tips on taking input from the public.
 </section>

--- a/_methods/kj-method.md
+++ b/_methods/kj-method.md
@@ -23,7 +23,8 @@ timeRequired: 1–2 hours
 1. Combine duplicates and their points if the entire group agrees they're identical. Three or four groups usually rank higher than the rest - these are the priorities for the question.
 
 <section class="method--section method--section--18f-example" markdown="1" >
-## Example from 18F
+
+## Example from 18F  
 
 18F conducted this exercise with 20 Federal Election Commission staff members to define priorities around conflicting requests. We used this method to get data from staff (not the decision makers) about what they saw as the most pressing needs. We synthesized and presented the data back to the decision makers.
 </section>

--- a/_methods/kj-method.md
+++ b/_methods/kj-method.md
@@ -36,7 +36,7 @@ timeRequired: 1–2 hours
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 At 18F, KJ participants are almost always federal employees. If there is any chance your KJ workshop could include participants who are not federal employees, consult OMB guidance on the Paperwork Reduction Act and the Privacy Act. Your agency's Office of General Counsel, and perhaps OIRA desk officers, also can ensure you are following the laws and regulations applicable to federal agencies.
 </section>

--- a/_methods/mental-modeling.md
+++ b/_methods/mental-modeling.md
@@ -28,7 +28,7 @@ timeRequired: 1–2 hours
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/multivariate-testing.md
+++ b/_methods/multivariate-testing.md
@@ -28,7 +28,8 @@ timeRequired: 2–5 days of effort, 1–4 weeks elapsed through the testing peri
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
-## Applied in government research
+
+## Considerations for use in government  
 
 No PRA implications. No one asks the users questions, so the PRA does not apply. See the methods for [Recruiting](/fundamentals/recruiting/#recruiting) and [Privacy](/fundamentals/privacy/#privacy) for more tips on taking input from the public.
 </section>

--- a/_methods/personas.md
+++ b/_methods/personas.md
@@ -37,7 +37,7 @@ timeRequired: 2–3 hours
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/privacy.md
+++ b/_methods/privacy.md
@@ -28,7 +28,7 @@ timeRequired: N/A
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 The government's use of information about people is subject to a number of laws and policies, including: [the Privacy Act of 1974](https://www.justice.gov/opcl/overview-privacy-act-1974-2015-edition), the Federal Information Security Management Act of 2002, and the eGovernment Act of 2002.
 

--- a/_methods/prototyping.md
+++ b/_methods/prototyping.md
@@ -22,7 +22,7 @@ timeRequired: 4 hours
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](/fundamentals/recruiting/#recruiting) and [Privacy](/fundamentals/privacy/#privacy) for more tips on taking input from the public.
 </section>

--- a/_methods/recruiting.md
+++ b/_methods/recruiting.md
@@ -28,7 +28,7 @@ timeRequired: 1–2 weeks for 5–10 participants
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/site-mapping.md
+++ b/_methods/site-mapping.md
@@ -20,7 +20,7 @@ timeRequired: 2–3 hours
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/stakeholder-and-user-interviews.md
+++ b/_methods/stakeholder-and-user-interviews.md
@@ -31,7 +31,7 @@ timeRequired: 1–2 hours per interviewee
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Government considerations
+## Considerations for use in government
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](/fundamentals/recruiting/) and [Privacy](/fundamentals/privacy/) for more tips on taking input from the public.
 </section>

--- a/_methods/stakeholder-and-user-interviews.md
+++ b/_methods/stakeholder-and-user-interviews.md
@@ -31,7 +31,7 @@ timeRequired: 1–2 hours per interviewee
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Government considerations
 
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](/fundamentals/recruiting/) and [Privacy](/fundamentals/privacy/) for more tips on taking input from the public.
 </section>

--- a/_methods/storyboarding.md
+++ b/_methods/storyboarding.md
@@ -30,7 +30,7 @@ timeRequired: 1–2 days depending on the complexity of the scenario(s)
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/style-tiles.md
+++ b/_methods/style-tiles.md
@@ -18,8 +18,9 @@ timeRequired: 1–2 days depending on how many rounds of feedback the team offer
 1. Create the appropriate number of style tiles based on the defined directions, which establish the specific visual language for the different directions.
 1. Gather stakeholder feedback. Iterate on the style tiles, eventually getting down to a single style tile which will be the established visual language for the project going forward.
 
-<section class="method--section method--section--additional-resources" markdown="1">
-## Additional resources
+<section class="method--section method--section--additional-resources" markdown="1"> 
+
+## Additional resources  
 
 - Tool: <a href="http://styletil.es/">Style Tiles: A Visual Web Design Process for Clients and the Responsive Web.</a> Style Tiles.
 - <a href="http://alistapart.com/article/style-tiles-and-how-they-work">"Style Tiles and How They Work."</a> Samantha Warren.
@@ -27,7 +28,7 @@ timeRequired: 1–2 days depending on how many rounds of feedback the team offer
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/task-flow-analysis.md
+++ b/_methods/task-flow-analysis.md
@@ -29,7 +29,7 @@ timeRequired: 2-3 hours per user goal
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/usability-testing.md
+++ b/_methods/usability-testing.md
@@ -43,7 +43,7 @@ timeRequired: 30 minutes to 1 hour per test
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government  
 
 No PRA implications. First, any given usability test should involve nine or fewer users. Additionally, the PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. It also specifically excludes tests of knowledge or aptitude, 5 CFR 1320.3(h)7, which is essentially what a usability test tests. See the methods for [Recruiting](/recruiting/) and [Privacy](/privacy/) for more tips on taking input from the public.
 </section>

--- a/_methods/user-scenarios.md
+++ b/_methods/user-scenarios.md
@@ -36,7 +36,7 @@ timeRequired: 1-3 hours
 
 <section class="method--section method--section--government-considerations" markdown="1" >
 
-## Applied in government research
+## Considerations for use in government
 
 No PRA implications. No information is collected from members of the public.
 </section>

--- a/_methods/visual-preference-testing.md
+++ b/_methods/visual-preference-testing.md
@@ -23,13 +23,16 @@ timeRequired: |
 1. Publish the results to the complete product team and decide which direction will guide future design efforts.
 
 <section class="method--section method--section--additional-resources" markdown="1">
-## Additional resources
+
+## Additional resources  
 
 - [Rapid Desirability Testing: A Case Study.](http://www.uxmatters.com/mt/archives/2010/02/rapid-desirability-testing-a-case-study.php) Michael Hawley.
 - [Preference and Desirability Testing: Measuring Emotional Response to Guide Design.](http://www.slideshare.net/pwdoncaster/preference-and-desirability-testing-measuring-emotional-response-to-guide-design) Michael Hawley and Paul Doncaster.
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >
-## Applied in government research
+
+## Considerations for use in government  
+
 No PRA implications. The PRA explicitly exempts direct observation and non-standardized conversation, 5 CFR 1320.3(h)3. See the methods for [Recruiting](/fundamentals/recruiting/#recruiting) and [Privacy](/fundamentals/privacy/#privacy) for more tips on taking input from the public.
 </section>

--- a/_methods/wireframing.md
+++ b/_methods/wireframing.md
@@ -19,6 +19,8 @@ timeRequired: 1-3 hours
 1. Use the wireframes to get the team's feedback on feasibility and structure.  
 
 <section class="method--section method--section--government-considerations" markdown="1" >
-## Applied in government research
+
+## Considerations for use in government  
+
 No PRA implications. No information is collected from members of the public.
 </section>


### PR DESCRIPTION
In response to feedback that the phrase "Applied in government research" has been a barrier to folks in certain agencies in which "research" implies a strict series of approvals, we're attempting to clarify this section. I am proposing "Government considerations" as a revised title for this section. 

This will have to be implemented individually on each method. 

Preview on one method [here](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/18f/methods/government-considerations/discover/stakeholder-and-user-interviews/).