### PR TITLE
Adds content audit to _data file

### DIFF
--- a/_data/categories.yml
+++ b/_data/categories.yml
@@ -17,6 +17,7 @@
   methods:
     - Affinity diagramming
     - Comparative analysis
+    - Content audit
     - Design hypothesis
     - Design principles
     - Journey mapping


### PR DESCRIPTION
Content audit has a dedicated markdown file, but it isn't generating in the list of methods on the homepage. It looks like the homepage loops through the `categories.yml` file to generate that list, so this PR adds "content audit" to the data file.