### PR TITLE
Fixes broken link to metrics definition

### DIFF
--- a/_methods/multivariate-testing.md
+++ b/_methods/multivariate-testing.md
@@ -14,7 +14,7 @@ timeRequired: 2–5 days of effort, 1–4 weeks elapsed through the testing peri
 ## How to do it
 
 1. Identify the call to action, content section, or feature that needs to be improved to increase conversion rates or user engagement.
-1. Develop a list of possible issues that may be hurting conversion rates or engagement. Specify in advance what you are optimizing for (possibly through [metrics definition](/discover/metrics-definition/#metrics-definition)).
+1. Develop a list of possible issues that may be hurting conversion rates or engagement. Specify in advance what you are optimizing for (possibly through [design hypothesis](/decide/design-hypothesis/)).
 1. Design several solutions that aim to address the issues listed. Each solution should attempt to address every issue by using a unique combination of variants so each solution can be compared fairly.
 1. Use a web analytics tool that supports multivariate testing, such as Google Website Optimizer or Visual Website Optimizer, to set up the testing environment. Conduct the test for long enough to produce statistically significant results.
 1. Analyze the testing results to determine which solution produced the best conversion or engagement rates. Review the other solutions, as well, to see if there is information worth examining in with future studies.  


### PR DESCRIPTION
The [multivariate testing method](https://methods.18f.gov/validate/multivariate-testing/) contains a broken link to "metrics analysis." It appears that method [was removed in an earlier release](https://methods.18f.gov/about/#210) and replaced with "design hypothesis." This PR replaces the broken link with the updated method.

