### PR TITLE
fix font size on feedback form input and textarea #445

### DIFF
--- a/_sass/touchpoints_overrides.scss
+++ b/_sass/touchpoints_overrides.scss
@@ -34,6 +34,7 @@
 #fba-modal-dialog#fba-modal-dialog .usa-input,
 #fba-modal-dialog#fba-modal-dialog .usa-textarea {
   max-width: 100%;
+  font-size: 1em;
 }
 #fba-modal-dialog#fba-modal-dialog .usa-button {
   font-size: 1em;


### PR DESCRIPTION
We deployed the Touchpoints feedback form, but realized that the inputs and textarea on the form displayed with too-small text. This PR fixes the sizing so that when you type in the form, the text displays at 1em (15px).

[Federalist preview](https://federalist-67816181-8ac2-428b-bc4e-be2d38d8f3ea.app.cloud.gov/preview/18f/methods/445-touchpoints-fix-font-size/)