### PR TITLE
Typo fix

### DIFF
--- a/_methods/task-flow-analysis.md
+++ b/_methods/task-flow-analysis.md
@@ -17,7 +17,7 @@ timeRequired: 2-3 hours per user goal
 1. For each goal, identify common scenarios and the tasks and decisions that the user or system will perform in each scenario. Don't assume you and your stakeholders share the same understanding of the tasks. The idea is to make the flow of tasks explicit in the diagram, so that you can check your understanding by walking through the diagram with users (steps 4 & 5).
 1. Produce a diagram that includes each task and decision point that a user might encounter on their way toward their goal. While there are several diagrammatic languages that can be used to produce task flow diagrams, the basic look is a flow chart of boxes for tasks and decision points and arrows showing directionality and dependencies among tasks. The diagram should cover the common scenarios identified in step 2.
 1. Present the diagram to a subject matter expert who knows the task(s) well enough to check for accuracy.
-1. In collaboration with users and/or subject matter exprts, annotate the task flow diagram to pinpoint areas of interest, risk, or potential frustration.
+1. In collaboration with users and/or subject matter experts, annotate the task flow diagram to pinpoint areas of interest, risk, or potential frustration.
 
 <section class="method--section method--section--additional-resources" markdown="1">
 


### PR DESCRIPTION
What was wrong:
"exprt" was misspelled at the end of the "How to do it" section 

What was changed:
"exprt" became "expert"