### PR TITLE
Cannandev change touchpoints label

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,4 +113,4 @@ DEPENDENCIES
   rouge
 
 BUNDLED WITH
-   1.17.3
+   2.1.2

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,16 +5,20 @@
     </div>
     <div class="usa-footer__primary-section site-footer">
         <div class="usa-footer__primary-container">
-          <p>This project is maintained by <a href="https://18f.gsa.gov" class="usa-link">18F</a>. To share your feedback with us, click the Provide Feedback button or open an issue or pull request on our <a href="https://github.com/18F/methods" class="usa-link">GitHub repository.</a></p>
+            <p>This project is maintained by <a href="https://18f.gsa.gov" class="usa-link">18F</a>. To share your
+                feedback with us, click the Provide Feedback button or open an issue or pull request on our <a
+                    href="https://github.com/18F/methods" class="usa-link">GitHub repository.</a></p>
         </div>
     </div>
     {% include usa_identifier.html %}
 </footer>
 
-<a id="fba-button" class="fixed-tab-button" href="https://touchpoints.app.cloud.gov/touchpoints/d028f982/submit" target="_blank">
-    Provide feedback
+<a id="fba-button" class="fixed-tab-button" href="https://touchpoints.app.cloud.gov/touchpoints/d028f982/submit"
+    target="_blank">
+    Get in touch
 </a>
 
 <!--<script src="{{site.baseurl}}/assets/js/site.js"/>-->
 <!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
-<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&subagency=18F,TTS"></script>
+<script id="_fed_an_ua_tag"
+    src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA&subagency=18F,TTS"></script>


### PR DESCRIPTION
### What's wrong?
The methods.18f.gov site does not have the 18F email address as the contact. Instead it has a Touchpoints button labeled **Provide feedback** in the footer area.

To pass the scan, the label text should be one of the following:
- Contact Us
- Contact
- **Get in touch** 👈🏾 The `guide-admins` team chose this one
- Email Us
- Help Desk

**Before this change:** 
![image](https://user-images.githubusercontent.com/381122/186513426-aad1fc32-7a6a-4728-b53a-4fd166c86231.png)

### What did I fix?
Changed the label text to Get in touch.

**After this change:** 
![image](https://user-images.githubusercontent.com/381122/186513281-92a96ee5-e028-4170-bc9f-a29f27f2a36f.png)


**Federalist Preview URL:** https://federalist-67816181-8ac2-428b-bc4e-be2d38d8f3ea.app.cloud.gov/preview/18f/methods/cannandev-change-touchpoints-label/