### PR TITLE
Fix mobile button overlay by making desktop breakpoints consistent

### DIFF
--- a/_sass/sticky.scss
+++ b/_sass/sticky.scss
@@ -1,12 +1,11 @@
-@media screen and (min-width: 100px) {
-  .banner {
-    position: sticky;
-    top: 0;
-    z-index: 300; // matches 300 z-index of .usa-header
-    background-color: white;
-  }
+.banner {
+  position: sticky;
+  top: 0;
+  z-index: 300; // matches 300 z-index of .usa-header
+  background-color: white;
 }
-@media screen and (min-width: 950px) {
+
+@include at-media('desktop') {
   .banner {
     position: relative;
   }


### PR DESCRIPTION
Closes #544

Essentially, the switch from mobile to desktop menu and the switch from mobile to desktop sticky banner were not aligning, because two different breakpoints were being used. This caused a slight window (from 950px to 64em) where css was conflicting and causing the mobile menu to rest behind the overlay. 

Using the standard USWDS breakpoint for both makes them sync up and removes the conflict. 

`@include at-media('desktop')` translates to a breakpoint of `min-width:64em` whereas `950px`, the old breakpoint, translates to `59.3em`.

I also removed the `min-width:100px` breakpoint since it was redundant. 

Tagging @MelissaBraxton as reporter of the original bug
Tagging @mgwalker for engineering review
