### PR TITLE
Add link testing, label syncing, and issue labeling

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -13,7 +13,7 @@ jobs:
       - name: check that root-relative internal links are prefixed
         uses: mgwalker/action-no-root-relative-links@v1
         with:
-          path: _pages
+          path: pages
           message: Internal link begins with /, but should begin with {{ site.baseurl }}/
 
   internal-links:
@@ -27,6 +27,8 @@ jobs:
         with:
           ruby-version: 2.7
           bundler-cache: true
+      - name: build the site
+        run: bundle exec jekyll build
       - name: check for broken links
         uses: mgwalker/action-htmlproofer@v1
         with:

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -3,8 +3,8 @@ name: invalid links check
 on: [pull_request]
 
 jobs:
-  root-relative-links:
-    name: no root-relative links in source
+  root-relative-links-pages:
+    name: no root-relative links in source (pages)
     runs-on: ubuntu-latest
     env:
       LANG: C.UTF-8
@@ -15,6 +15,14 @@ jobs:
         with:
           path: pages
           message: Internal link begins with /, but should begin with {{ site.baseurl }}/
+
+  root-relative-links-methods:
+    name: no root-relative links in source (methods)
+    runs-on: ubuntu-latest
+    env:
+      LANG: C.UTF-8
+    steps:
+      - uses: actions/checkout@v3
       - name: check that root-relative internal links are prefixed (methods)
         uses: mgwalker/action-no-root-relative-links@v1
         with:

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -10,10 +10,15 @@ jobs:
       LANG: C.UTF-8
     steps:
       - uses: actions/checkout@v3
-      - name: check that root-relative internal links are prefixed
+      - name: check that root-relative internal links are prefixed (pages)
         uses: mgwalker/action-no-root-relative-links@v1
         with:
           path: pages
+          message: Internal link begins with /, but should begin with {{ site.baseurl }}/
+      - name: check that root-relative internal links are prefixed (methods)
+        uses: mgwalker/action-no-root-relative-links@v1
+        with:
+          path: _methods
           message: Internal link begins with /, but should begin with {{ site.baseurl }}/
 
   internal-links:

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -1,0 +1,45 @@
+name: invalid links check
+
+on: [pull_request]
+
+jobs:
+  root-relative-links:
+    name: no root-relative links in source
+    runs-on: ubuntu-latest
+    env:
+      LANG: C.UTF-8
+    steps:
+      - uses: actions/checkout@v3
+      - name: check that root-relative internal links are prefixed
+        uses: mgwalker/action-no-root-relative-links@v1
+        with:
+          path: _pages
+          message: Internal link begins with /, but should begin with {{ site.baseurl }}/
+
+  internal-links:
+    name: verify internal links are valid
+    runs-on: ubuntu-latest
+    env:
+      LANG: C.UTF-8
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: check for broken links
+        uses: mgwalker/action-htmlproofer@v1
+        with:
+          path: _site
+          args: --disable-external --allow-missing-href
+      - name: comment on the PR
+        if: ${{ failure() }}
+        uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `At least one link is invalid. Please check the output of the tests in the checks below. For more information, see the [wiki page on automated tests](https://github.com/18F/ux-guide/wiki/Automated-testing).`
+            });

--- a/.github/workflows/label_new_issues.yml
+++ b/.github/workflows/label_new_issues.yml
@@ -1,0 +1,18 @@
+name: Label new issues
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  initialize:
+    name: Label new issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: add label
+        uses: christianvuerings/add-labels@v1.1
+        with:
+          labels: new issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,16 @@
+name: Sync labels from UX Guide repo
+
+on:
+ schedule:
+   # daily at 3am UTC so as to probably not disrupt anyone
+   - cron: '0 3 * * *'
+
+jobs:
+  labels:
+    name: synchronize labels from UX Guide repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: sync labels from UX Guide repo
+        uses: EndBug/label-sync@v2
+        with:
+          source-repo: 18F/ux-guide


### PR DESCRIPTION
This pull requests adds some automations, like what has been previously added to the [UX guide](/18f/ux-guide):

- verify that there are no root-relative links in the source code
- verify that there are no invalid internal links in the build HTML
- synchronize labels with the UX guide repo nightly
- add the "new issue" label to newly-created issues, so maintenance teams can quickly know what has/has not been triaged