### PR TITLE
Replace HTTP links with HTTPS links, where possible

### DIFF
--- a/_methods/affinity-mapping.md
+++ b/_methods/affinity-mapping.md
@@ -24,7 +24,7 @@ timeRequired: 1 hour
 
 ## Additional resources
 
-- <a href="http://www.usabilitybok.org/affinity-diagram" class="usa-link">
+- <a href="https://www.usabilitybok.org/affinity-diagram" class="usa-link">
       An explanation of what affinity mapping is and how to do it.
     </a> The Usability Body of Knowledge, a product of the User Experience Professionals' Association.
 - <a href="http://infodesign.com.au/usabilityresources/affinitydiagramming/" class="usa-link">An explanation of affinity mapping</a> information and Design.

--- a/_methods/cognitive-walkthrough.md
+++ b/_methods/cognitive-walkthrough.md
@@ -25,7 +25,7 @@ timeRequired: 30 minutes to one hour per person
 
 ## Additional resources
 
-- <a href="http://www.usabilitybok.org/cognitive-walkthrough" class="usa-link">
+- <a href="https://www.usabilitybok.org/cognitive-walkthrough" class="usa-link">
       An explanation of cognitive walkthroughs and how to conduct one.
     </a> The Usability Body of Knowledge, a product of the User Experience Professionals' Association.
 

--- a/_methods/content-audit.md
+++ b/_methods/content-audit.md
@@ -42,7 +42,7 @@ timeRequired: 3-8 hours
 
 ## Additional resources
 
-- <a href="http://uxmastery.com/how-to-conduct-a-content-audit/" class="usa-link">"How to Conduct a Content Audit."</a> UX Mastery.
+- <a href="https://uxmastery.com/how-to-conduct-a-content-audit/" class="usa-link">"How to Conduct a Content Audit."</a> UX Mastery.
 - <a href="https://www.braintraffic.com/blog/how-to-audit-big-websites" class="usa-link">"How to Audit Big Websites"</a> Christine Anameier.
 - <a href="https://www.usability.gov/how-to-and-tools/methods/content-inventory.html" class="usa-link">"Content Inventory."</a> usability.gov
 </section>

--- a/_methods/design-principles.md
+++ b/_methods/design-principles.md
@@ -33,7 +33,7 @@ timeRequired: 1 week, plus occasional refresher meetings
 
 ## Additional resources
 
-- <a href="http://www.smashingmagazine.com/2015/02/27/design-principles-dominance-focal-points-hierarchy/" class="usa-link">"Design Principles: Dominance, Focal Points And Hierarchy."</a> Steven Bradley.
+- <a href="https://www.smashingmagazine.com/2015/02/27/design-principles-dominance-focal-points-hierarchy/" class="usa-link">"Design Principles: Dominance, Focal Points And Hierarchy."</a> Steven Bradley.
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >

--- a/_methods/heuristic-evaluation.md
+++ b/_methods/heuristic-evaluation.md
@@ -27,8 +27,8 @@ timeRequired: 1–2 hours
 
 ## Additional resources
 
-- <a href="http://www.nngroup.com/articles/ten-usability-heuristics/" class="usa-link">"10 Usability Heuristics for User Interface Design."</a> Jakob Nielsen.
-- <a href="http://www.nngroup.com/articles/how-to-conduct-a-heuristic-evaluation/" class="usa-link">"How to Conduct a Heuristic Evaluation."</a> Jakob Nielsen.
+- <a href="https://www.nngroup.com/articles/ten-usability-heuristics/" class="usa-link">"10 Usability Heuristics for User Interface Design."</a> Jakob Nielsen.
+- <a href="https://www.nngroup.com/articles/how-to-conduct-a-heuristic-evaluation/" class="usa-link">"How to Conduct a Heuristic Evaluation."</a> Jakob Nielsen.
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >

--- a/_methods/journey-mapping.md
+++ b/_methods/journey-mapping.md
@@ -31,7 +31,7 @@ timeRequired: 4–12 hours
 - <a href="https://coe.gsa.gov/2019/04/17/cx-update-9.html" class="usa-link">3-part series on the what, why, and how of journey mapping</a> by GSA's Customer Experience Center of Excellence
 - <a href="http://adaptivepath.s3.amazonaws.com/apguide/download/Adaptive_Paths_Guide_to_Experience_Mapping.pdf" class="usa-link">Adaptive Path's Guide to Experience Mapping.</a> Adaptive Path (PDF).
 - <a href="https://www.wickedproblems.com/6_journey_maps.php" class="usa-link">An explanation of journey mapping on Wicked Problems Worth Solving.</a> Austin Center for Design.
-- <a href="http://www.uxbooth.com/articles/designing-digital-strategies-part-1-cartography/" class="usa-link">"Designing Digital Strategies, Part 1: Cartography."</a> UX Booth.
+- <a href="https://www.uxbooth.com/articles/designing-digital-strategies-part-1-cartography/" class="usa-link">"Designing Digital Strategies, Part 1: Cartography."</a> UX Booth.
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >

--- a/_methods/lean-coffee.md
+++ b/_methods/lean-coffee.md
@@ -35,7 +35,7 @@ At 18F, Lean coffee is often used to facilitate community of practice meetings a
 
 ## Additional resources
 
-- <a href="http://agilecoffee.com/leancoffee/" class="usa-link">Extended description of Lean coffee</a> from Agile Coffee
+- <a href="https://agilecoffee.com/leancoffee/" class="usa-link">Extended description of Lean coffee</a> from Agile Coffee
 
 </section>
 

--- a/_methods/mental-modeling.md
+++ b/_methods/mental-modeling.md
@@ -22,8 +22,8 @@ timeRequired: 1–2 hours
 
 ## Additional resources
 
-- Book: <a href="http://rosenfeldmedia.com/books/mental-models/" class="usa-link"><em>Mental Models: Aligning Design Strategy with Human Behavior.</em></a> Indi Young.
-- <a href="http://uxmag.com/articles/the-secret-to-designing-an-intuitive-user-experience" class="usa-link">"The Secret to Designing an Intuitive UX: Match the Mental Model to the Conceptual Model."</a> Susan Weinschenk, UX Magazine.
+- Book: <a href="https://rosenfeldmedia.com/books/mental-models/" class="usa-link"><em>Mental Models: Aligning Design Strategy with Human Behavior.</em></a> Indi Young.
+- <a href="https://uxmag.com/articles/the-secret-to-designing-an-intuitive-user-experience" class="usa-link">"The Secret to Designing an Intuitive UX: Match the Mental Model to the Conceptual Model."</a> Susan Weinschenk, UX Magazine.
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >

--- a/_methods/multivariate-testing.md
+++ b/_methods/multivariate-testing.md
@@ -23,8 +23,8 @@ timeRequired: 2–5 days of effort, 1–4 weeks elapsed through the testing peri
 
 ## Additional resources
 
-- <a href="http://www.smashingmagazine.com/2010/11/multivariate-testing-in-action-five-simple-steps-to-increase-conversion-rates/" class="usa-link">Multivariate Testing in Action: Five Simple Steps to Increase Conversion Rates. Paras Chopra.</a>
-- <a href="http://www.smashingmagazine.com/2011/04/multivariate-testing-101-a-scientific-method-of-optimizing-design/" class="usa-link">Multivariate Testing 101: A Scientific Method of Optimizing Design. Paras Chopra.</a>
+- <a href="https://www.smashingmagazine.com/2010/11/multivariate-testing-in-action-five-simple-steps-to-increase-conversion-rates/" class="usa-link">Multivariate Testing in Action: Five Simple Steps to Increase Conversion Rates. Paras Chopra.</a>
+- <a href="https://www.smashingmagazine.com/2011/04/multivariate-testing-101-a-scientific-method-of-optimizing-design/" class="usa-link">Multivariate Testing 101: A Scientific Method of Optimizing Design. Paras Chopra.</a>
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >

--- a/_methods/storyboarding.md
+++ b/_methods/storyboarding.md
@@ -23,9 +23,9 @@ timeRequired: 1–2 days depending on the complexity of the scenario(s)
 
 ## Additional resources
 
-- Tool: <a href="http://www.servicedesigntools.org/tools/13" class="usa-link">Communication Methods Supporting Design Processes.</a> Service Design Tools.
-- <a href="http://uxmag.com/articles/storyboarding-in-the-software-design-process" class="usa-link">"Storyboarding in the Software Design Process."</a> Ambrose Little.
-- <a href="http://www.fastcodesign.com/1672917/the-8-steps-to-creating-a-great-storyboard" class="usa-link">"The 8 Steps to Creating a Great Storyboard."</a> Jake Knapp.
+- Tool: <a href="https://www.servicedesigntools.org/tools/13" class="usa-link">Communication Methods Supporting Design Processes.</a> Service Design Tools.
+- <a href="https://uxmag.com/articles/storyboarding-in-the-software-design-process" class="usa-link">"Storyboarding in the Software Design Process."</a> Ambrose Little.
+- <a href="https://www.fastcodesign.com/1672917/the-8-steps-to-creating-a-great-storyboard" class="usa-link">"The 8 Steps to Creating a Great Storyboard."</a> Jake Knapp.
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >

--- a/_methods/style-tiles.md
+++ b/_methods/style-tiles.md
@@ -22,8 +22,8 @@ timeRequired: 1–2 days depending on how many rounds of feedback the team offer
 
 ## Additional resources
 
-- Tool: <a href="http://styletil.es/" class="usa-link">Style Tiles: A Visual Web Design Process for Clients and the Responsive Web.</a> Style Tiles.
-- <a href="http://alistapart.com/article/style-tiles-and-how-they-work" class="usa-link">"Style Tiles and How They Work."</a> Samantha Warren.
+- Tool: <a href="https://styletil.es/" class="usa-link">Style Tiles: A Visual Web Design Process for Clients and the Responsive Web.</a> Style Tiles.
+- <a href="https://alistapart.com/article/style-tiles-and-how-they-work" class="usa-link">"Style Tiles and How They Work."</a> Samantha Warren.
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >

--- a/_methods/task-flow-analysis.md
+++ b/_methods/task-flow-analysis.md
@@ -23,8 +23,8 @@ timeRequired: 2-3 hours per user goal
 
 ## Additional resources
 
-- <a href="http://searchenginewatch.com/sew/how-to/2336547/task-analysis-the-key-ux-design-step-everyone-skips" class="usa-link">"Task Analysis: The Key UX Design Step Everyone Skips." Larry Marine.</a>
-- Tool: <a href="http://www.usability.gov/how-to-and-tools/methods/task-analysis.html" class="usa-link">Task Analysis.</a> Usability.gov
+- <a href="https://searchenginewatch.com/sew/how-to/2336547/task-analysis-the-key-ux-design-step-everyone-skips" class="usa-link">"Task Analysis: The Key UX Design Step Everyone Skips." Larry Marine.</a>
+- Tool: <a href="https://www.usability.gov/how-to-and-tools/methods/task-analysis.html" class="usa-link">Task Analysis.</a> Usability.gov
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >

--- a/_methods/visual-preference-testing.md
+++ b/_methods/visual-preference-testing.md
@@ -26,8 +26,8 @@ timeRequired: |
 
 ## Additional resources
 
-- <a href="http://www.uxmatters.com/mt/archives/2010/02/rapid-desirability-testing-a-case-study.php" class="usa-link">Rapid Desirability Testing: A Case Study.</a> Michael Hawley.
-- <a href="http://www.slideshare.net/pwdoncaster/preference-and-desirability-testing-measuring-emotional-response-to-guide-design" class="usa-link">Preference and Desirability Testing: Measuring Emotional Response to Guide Design.</a> Michael Hawley and Paul Doncaster.
+- <a href="https://www.uxmatters.com/mt/archives/2010/02/rapid-desirability-testing-a-case-study.php" class="usa-link">Rapid Desirability Testing: A Case Study.</a> Michael Hawley.
+- <a href="https://www.slideshare.net/pwdoncaster/preference-and-desirability-testing-measuring-emotional-response-to-guide-design" class="usa-link">Preference and Desirability Testing: Measuring Emotional Response to Guide Design.</a> Michael Hawley and Paul Doncaster.
 </section>
 
 <section class="method--section method--section--government-considerations" markdown="1" >

--- a/pages/participant-agreement-spanish.md
+++ b/pages/participant-agreement-spanish.md
@@ -62,7 +62,7 @@ La investigación de diseño de `<Organización>` se lleva a cabo en el espírit
   <ol>
     <li id="footnote-pia">
       <p>See <a href="https://www.gsa.gov/portal/content/162010">https://www.gsa.gov/portal/content/162010</a> and <a href="https://www.gsa.gov/portal/content/102237">https://www.gsa.gov/portal/content/102237</a></p>
-      <a href="#footnote-pia-ref" aria-label="Back to content">↩</a>
+      <a href="#footnote-pia" aria-label="Back to content">↩</a>
     </li>
   </ol>
 </footer>

--- a/pages/rolling-issues-log.md
+++ b/pages/rolling-issues-log.md
@@ -13,7 +13,7 @@ permalink: /rolling-issues-log/
 
 # Example Rolling Issues Log
 
-This document is a template for teams to use while observing or debriefing after a [usability test]({{site.baseurl}}/usability-testing). It's inspired by [this blog post](http://usabilityworks.com/consensus-on-observations-in-real-time-keeping-a-rolling-list-of-issues/). GSA Staff, please see this [Google Doc Template](https://docs.google.com/spreadsheets/d/1QQIXrvNR4kCUb7xwE0r4mqSNXok2A8ynksA5Bo7Za3E/edit#).
+This document is a template for teams to use while observing or debriefing after a [usability test]({{site.baseurl}}/usability-testing). It's inspired by [this blog post](https://danachisnell.com/consensus-on-observations-in-real-time-keeping-a-rolling-list-of-issues/). GSA Staff, please see this [Google Doc Template](https://docs.google.com/spreadsheets/d/1QQIXrvNR4kCUb7xwE0r4mqSNXok2A8ynksA5Bo7Za3E/edit#).
 
 
 ## Study 1 – Usability test of `[scenario, task, feature]`

--- a/pages/usability-test-script.md
+++ b/pages/usability-test-script.md
@@ -72,4 +72,4 @@ Who else should we talk to?
 
 ### References
 
-- [Steve Krug’s Usability Test Script](http://sensible.com/downloads/test-script-web.pdf)
+- [Steve Krug’s Usability Test Script](https://sensible.com/downloads/test-script-web.pdf)

--- a/pages/user-interview-script.md
+++ b/pages/user-interview-script.md
@@ -68,4 +68,4 @@ Would you be open to speaking with us again in the future?
 Who else should we talk to?
 ### References
 
-- [Steve Krug’s Usability Test Script](http://sensible.com/downloads/test-script-web.pdf)
+- [Steve Krug’s Usability Test Script](https://sensible.com/downloads/test-script-web.pdf)


### PR DESCRIPTION
The following links were not updated because they are now 404s:

- Affinity mapping: [An explanation of affinity mapping](http://infodesign.com.au/usabilityresources/affinitydiagramming/) information and Design.
- Journey mapping: [Adaptive Path's Guide to Experience Mapping](http://adaptivepath.s3.amazonaws.com/apguide/download/Adaptive_Paths_Guide_to_Experience_Mapping.pdf) Adaptive Path (PDF)
- Interview checklist: there's a link to a methods page called "incentives," but there's not a page for that. So... that link is staying put too.

These two links only show up once each in the source, but because of how Methods are rendered, they appear multiple times in the built site.

Closes #579 