### PR TITLE
Repo sync

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -4,7 +4,7 @@ group:
       18f/methods
       18f/ux-guide
     files:
-      - source: .github/workflows/sync_templates.yml
+      # - source: .github/workflows/sync_templates.yml
       - source: .github/sync.yml
       - source: .github/ISSUE_TEMPLATE/
         deleteOrphaned: true

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -4,7 +4,6 @@ group:
       18f/methods
       18f/ux-guide
     files:
-      # - source: .github/workflows/sync_templates.yml
       - source: .github/sync.yml
       - source: .github/ISSUE_TEMPLATE/
         deleteOrphaned: true

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -4,8 +4,8 @@ group:
       18f/methods
       18f/ux-guide
     files:
-      - .github/workflows/sync_templates.yml
-      - .github/sync.yml
+      - source: .github/workflows/sync_templates.yml
+      - source: .github/sync.yml
       - source: .github/ISSUE_TEMPLATE/
         deleteOrphaned: true
       - source: .github/ISSUE_TEMPLATE.md

--- a/.github/workflows/sync_templates.yml
+++ b/.github/workflows/sync_templates.yml
@@ -11,7 +11,7 @@ on:
       - .github/ISSUE_TEMPLATE.md
       - .github/PULL_REQUEST_TEMPLATE/*
       - .github/PULL_REQUEST_TEMPLATE.md
-      - .github/workflows/sync_templates.yml
+      # - .github/workflows/sync_templates.yml
 
 jobs:
   initialize:

--- a/.github/workflows/sync_templates.yml
+++ b/.github/workflows/sync_templates.yml
@@ -4,14 +4,6 @@ on:
   push:
     branches:
       - main
-      - repo-sync
-    paths:
-      - .github/sync.yml
-      - .github/ISSUE_TEMPLATE/*
-      - .github/ISSUE_TEMPLATE.md
-      - .github/PULL_REQUEST_TEMPLATE/*
-      - .github/PULL_REQUEST_TEMPLATE.md
-      # - .github/workflows/sync_templates.yml
 
 jobs:
   initialize:

--- a/.github/workflows/sync_templates.yml
+++ b/.github/workflows/sync_templates.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - repo-sync
     paths:
       - .github/sync.yml
       - .github/ISSUE_TEMPLATE/*


### PR DESCRIPTION
Lesson learned: we can't synchronize workflow files between repos without giving the GitHub app additional permissions. That seems fine for now. Our goal was to sync issue/PR templates and we can do that, so... huzzah!