### PR TITLE
Footer and touchpoints CTA updates

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,7 +15,7 @@ To share your feedback about the Methods site, click the <strong>Provide feedbac
 
 <a id="fba-button" class="fixed-tab-button" href="https://touchpoints.app.cloud.gov/touchpoints/d028f982/submit"
     target="_blank">
-    Get in touch
+    Provide feedback
 </a>
 
 <!--Add SVG for header links-->

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,8 +5,8 @@
     </div>
     <div class="usa-footer__primary-section site-footer">
         <div class="usa-footer__primary-container">
-            <p>This project is maintained by <a href="https://18f.gsa.gov" class="usa-link">18F</a>. To share your
-                feedback with us, click the <strong>Get in touch</strong> button or open an issue or pull request on our
+            <p>This project is maintained by <a href="https://18f.gsa.gov" class="usa-link">18F</a>. To get in touch with us, head to the <a href="https://18f.gsa.gov/contact/" class="usa-link">18F contact page.</a> 
+To share your feedback about the Methods site, click the <strong>Provide feedback<strong> button or open an issue or pull request on our
                 <a href="https://github.com/18F/methods" class="usa-link">GitHub repository.</a></p>
         </div>
     </div>


### PR DESCRIPTION
This PR updates the touchpoints CTA and the "contact us" approach in the footer. 

**Problems this solves:** 
 - Current touchpoints CTA says "get in touch." We noticed that touchpoints responses are a mix of feedback and questions that expect a response. We hypothesize that "get in touch" is a bit vague and may mislead some users to think it's opening up a 2-way conversation, when the intention is really to focus in on feedback. 
 
**What we did:** 
 - To help ensure that questions that require a response are routed correctly, we've revised the footer to point people to the 18F contact page if they want to get in touch. We've also revised the footer to make it more clear that the touchpoints intercept is designed to collect feedback on the Methods site specifically, and changed the CTA from "get in touch" to "provide feedback."  
 - The site should still meet scanning requirements for having a contact listed since we do still provide a clear way for folks to get in touch. 
 
 