### PR TITLE
Add milestone syncing

### DIFF
--- a/.github/workflows/sync_milestones.yml
+++ b/.github/workflows/sync_milestones.yml
@@ -33,7 +33,7 @@ jobs:
             console.log(syncTargets.join(", "));
 
             const myMilestones = await github
-              .paginate(`GET /repos/${owner}/${"methods"}/milestones`)
+              .paginate(`GET /repos/${owner}/${repo}/milestones`)
               .then((milestones) =>
                 milestones.map(({ title, description, due_on, state }) => ({
                   title,
@@ -50,7 +50,7 @@ jobs:
             for await (const target of syncTargets) {
               const theirMilestones = new Set(
                 await github
-                  .paginate(`GET /repos/${owner}/${"methods"}/milestones`)
+                  .paginate(`GET /repos/${owner}/${target}/milestones`)
                   .then((milestones) => milestones.map(({ title }) => title))
               );
               console.log(theirMilestones);

--- a/.github/workflows/sync_milestones.yml
+++ b/.github/workflows/sync_milestones.yml
@@ -29,8 +29,6 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const syncTargets = ["methods", "ux-guide"].filter((r) => r !== repo);
-            console.log("Targets:");
-            console.log(syncTargets.join(", "));
 
             const myMilestones = await github
               .paginate(`GET /repos/${owner}/${repo}/milestones`)
@@ -42,10 +40,6 @@ jobs:
                   state,
                 }))
               );
-            const milestoneNames = new Set(myMilestones.map(({ title }) => title));
-            console.log("My milestones:")
-            console.log(milestoneNames);
-            console.log("============")
 
             for await (const target of syncTargets) {
               const theirMilestones = new Set(
@@ -53,12 +47,12 @@ jobs:
                   .paginate(`GET /repos/${owner}/${target}/milestones`)
                   .then((milestones) => milestones.map(({ title }) => title))
               );
-              console.log(theirMilestones);
 
               for await (const milestone of myMilestones) {
                 if (!theirMilestones.has(milestone.title)) {
                   // create this milestone over there
-                  console.log(`add milestone ${milestone.title} to ${target}`);
+                  await github.issues.createMilestone({ owner, repo: target, ...milestone });
+                  break;
                 }
               }
             }

--- a/.github/workflows/sync_milestones.yml
+++ b/.github/workflows/sync_milestones.yml
@@ -22,14 +22,18 @@ jobs:
           installation_id: ${{ secrets.PROJECT_INSTALLATION_ID }}
           private_key: ${{ secrets.PROJECT_PRIVATE_KEY }}
       
-      - name: list milestones in this repo
+      - name: sync milestones
         uses: actions/github-script@v6
         with:
           github-token: ${{ steps.app_token.outputs.token }}
           script: |
+            // Get the metadata about this repo from the workflow context
             const { owner, repo } = context.repo;
+            // And remove this repo from the list of repos to sync to. No need
+            // to sync myself with myself.
             const syncTargets = ["methods", "ux-guide"].filter((r) => r !== repo);
 
+            // Get a list of this repo's milestones
             const myMilestones = await github
               .paginate(`GET /repos/${owner}/${repo}/milestones`)
               .then((milestones) =>
@@ -41,7 +45,10 @@ jobs:
                 }))
               );
 
+            // Now for each sync target repo...
             for await (const target of syncTargets) {
+              // Get the titles of their milestones, which we'll use to filter
+              // down to which milestones to synchronize
               const theirMilestones = new Set(
                 await github
                   .paginate(`GET /repos/${owner}/${target}/milestones`)
@@ -49,10 +56,12 @@ jobs:
               );
 
               for await (const milestone of myMilestones) {
+                // If a milestone with this title does NOT exist in the target
+                // repo, then we should create one.
                 if (!theirMilestones.has(milestone.title)) {
-                  // create this milestone over there
+                  // Expand the milestone so we push the title, description, due
+                  // date, and status (open/closed) all at once.
                   await github.rest.issues.createMilestone({ owner, repo: target, ...milestone });
-                  break;
                 }
               }
             }

--- a/.github/workflows/sync_milestones.yml
+++ b/.github/workflows/sync_milestones.yml
@@ -29,6 +29,8 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const syncTargets = ["methods", "ux-guide"].filter((r) => r !== repo);
+            console.log("Targets:");
+            console.log(syncTargets.join(", "));
 
             const myMilestones = await github
               .paginate(`GET /repos/${owner}/${"methods"}/milestones`)
@@ -41,6 +43,9 @@ jobs:
                 }))
               );
             const milestoneNames = new Set(myMilestones.map(({ title }) => title));
+            console.log("My milestones:")
+            console.log(milestoneNames);
+            console.log("============")
 
             for await (const target of syncTargets) {
               const theirMilestones = new Set(
@@ -48,6 +53,7 @@ jobs:
                   .paginate(`GET /repos/${owner}/${"methods"}/milestones`)
                   .then((milestones) => milestones.map(({ title }) => title))
               );
+              console.log(theirMilestones);
 
               for await (const milestone of myMilestones) {
                 if (!theirMilestones.has(milestone.title)) {

--- a/.github/workflows/sync_milestones.yml
+++ b/.github/workflows/sync_milestones.yml
@@ -1,9 +1,8 @@
 name: sync milestones
 
 on:
-  push:
-    branches:
-      - 374-milestone-syncing
+  milestone:
+    types: [created]
 
 jobs:
   synchronize:

--- a/.github/workflows/sync_milestones.yml
+++ b/.github/workflows/sync_milestones.yml
@@ -51,7 +51,7 @@ jobs:
               for await (const milestone of myMilestones) {
                 if (!theirMilestones.has(milestone.title)) {
                   // create this milestone over there
-                  await github.issues.createMilestone({ owner, repo: target, ...milestone });
+                  await github.rest.issues.createMilestone({ owner, repo: target, ...milestone });
                   break;
                 }
               }

--- a/.github/workflows/sync_milestones.yml
+++ b/.github/workflows/sync_milestones.yml
@@ -1,0 +1,59 @@
+name: sync milestones
+
+on:
+  push:
+    branches:
+      - 374-milestone-syncing
+
+jobs:
+  synchronize:
+    name: synchronize milestones
+    runs-on: ubuntu-latest
+
+    steps:
+      # Rather than use a personal access token to interact with the project, we
+      # can use this GitHub App. There's an API for exchanging app credentials
+      # for a short-term token, and we use that API here.
+      - name: get token
+        uses: tibdex/github-app-token@v1
+        id: app_token
+        with:
+          app_id: ${{ secrets.PROJECT_APP_ID }}
+          installation_id: ${{ secrets.PROJECT_INSTALLATION_ID }}
+          private_key: ${{ secrets.PROJECT_PRIVATE_KEY }}
+      
+      - name: list milestones in this repo
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ steps.app_token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const syncTargets = ["methods", "ux-guide"].filter((r) => r !== repo);
+
+            const myMilestones = await github
+              .paginate(`GET /repos/${owner}/${"methods"}/milestones`)
+              .then((milestones) =>
+                milestones.map(({ title, description, due_on, state }) => ({
+                  title,
+                  description,
+                  due_on,
+                  state,
+                }))
+              );
+            const milestoneNames = new Set(myMilestones.map(({ title }) => title));
+
+            for await (const target of syncTargets) {
+              const theirMilestones = new Set(
+                await github
+                  .paginate(`GET /repos/${owner}/${"methods"}/milestones`)
+                  .then((milestones) => milestones.map(({ title }) => title))
+              );
+
+              for await (const milestone of myMilestones) {
+                if (!theirMilestones.has(milestone.title)) {
+                  // create this milestone over there
+                  console.log(`add milestone ${milestone.title} to ${target}`);
+                }
+              }
+            }
+


### PR DESCRIPTION
Adds an automation to sync creation of milestones. When a milestone is created in this repo, the same milestone is also created in the [ux-guide](/18F/ux-guide) repo.

- Addresses 18F/ux-guide#374

@cannandev: Please review the GitHub Actions code. It is identical to 18F/ux-guide#382
@MelissaBraxton and/or @bpdesigns: Please review the behavior describe above to make sure it's right.